### PR TITLE
ACTIVEMQ6-40 Update to the geronimo jms 2 spec JAR.

### DIFF
--- a/activemq-jms-client/pom.xml
+++ b/activemq-jms-client/pom.xml
@@ -27,8 +27,8 @@
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.jboss.spec.javax.jms</groupId>
-         <artifactId>jboss-jms-api_2.0_spec</artifactId>
+         <groupId>org.apache.geronimo.specs</groupId>
+         <artifactId>geronimo-jms_2.0_spec</artifactId>
       </dependency>
       <dependency>
          <groupId>javax.inject</groupId>

--- a/activemq-jms-server/pom.xml
+++ b/activemq-jms-server/pom.xml
@@ -42,8 +42,8 @@
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.jboss.spec.javax.jms</groupId>
-         <artifactId>jboss-jms-api_2.0_spec</artifactId>
+         <groupId>org.apache.geronimo.specs</groupId>
+         <artifactId>geronimo-jms_2.0_spec</artifactId>
       </dependency>
       <dependency>
          <groupId>org.apache.geronimo.specs</groupId>

--- a/activemq-protocols/activemq-amqp-protocol/pom.xml
+++ b/activemq-protocols/activemq-amqp-protocol/pom.xml
@@ -55,12 +55,9 @@
          <groupId>org.apache.qpid</groupId>
          <artifactId>proton-jms</artifactId>
       </dependency>
-
-
-
       <dependency>
-         <groupId>org.jboss.spec.javax.jms</groupId>
-         <artifactId>jboss-jms-api_2.0_spec</artifactId>
+         <groupId>org.apache.geronimo.specs</groupId>
+         <artifactId>geronimo-jms_2.0_spec</artifactId>
          <scope>provided</scope>
       </dependency>
       <dependency>

--- a/activemq-protocols/activemq-proton-plug/pom.xml
+++ b/activemq-protocols/activemq-proton-plug/pom.xml
@@ -63,8 +63,8 @@
 
 
       <dependency>
-         <groupId>org.jboss.spec.javax.jms</groupId>
-         <artifactId>jboss-jms-api_2.0_spec</artifactId>
+         <groupId>org.apache.geronimo.specs</groupId>
+         <artifactId>geronimo-jms_2.0_spec</artifactId>
          <scope>provided</scope>
       </dependency>
       <dependency>

--- a/activemq-rest/pom.xml
+++ b/activemq-rest/pom.xml
@@ -75,8 +75,8 @@
          <version>${activemq.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.jboss.spec.javax.jms</groupId>
-         <artifactId>jboss-jms-api_2.0_spec</artifactId>
+         <groupId>org.apache.geronimo.specs</groupId>
+         <artifactId>geronimo-jms_2.0_spec</artifactId>
       </dependency>
       <dependency>
          <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>
+   <parent>
+      <groupId>org.apache</groupId>
+      <artifactId>apache</artifactId>
+      <version>16</version>
+   </parent>
    <groupId>org.apache.activemq</groupId>
    <artifactId>activemq-pom</artifactId>
    <packaging>pom</packaging>
@@ -73,6 +78,7 @@
       <activemq.basedir>${project.basedir}</activemq.basedir>
       <skipLicenseCheck>false</skipLicenseCheck>
       <skipStyleCheck>false</skipStyleCheck>
+      <geronimo.jms.2.spec.version>1.0.0-SNAPSHOT</geronimo.jms.2.spec.version>
    </properties>
 
    <scm>
@@ -191,9 +197,9 @@
 
          <!-- needed to compile JMS-->
          <dependency>
-            <groupId>org.jboss.spec.javax.jms</groupId>
-            <artifactId>jboss-jms-api_2.0_spec</artifactId>
-            <version>1.0.0.Final</version>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jms_2.0_spec</artifactId>
+            <version>${geronimo.jms.2.spec.version}</version>
          </dependency>
 
          <!-- needed to provide JMS injection-->

--- a/tests/byteman-tests/pom.xml
+++ b/tests/byteman-tests/pom.xml
@@ -136,8 +136,8 @@
          <artifactId>geronimo-jaspi</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.jboss.spec.javax.jms</groupId>
-         <artifactId>jboss-jms-api_2.0_spec</artifactId>
+         <groupId>org.apache.geronimo.specs</groupId>
+         <artifactId>geronimo-jms_2.0_spec</artifactId>
       </dependency>
       <dependency>
          <groupId>org.jboss.logging</groupId>

--- a/tests/jms-tests/pom.xml
+++ b/tests/jms-tests/pom.xml
@@ -105,8 +105,8 @@
          <artifactId>geronimo-jaspi</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.jboss.spec.javax.jms</groupId>
-         <artifactId>jboss-jms-api_2.0_spec</artifactId>
+         <groupId>org.apache.geronimo.specs</groupId>
+         <artifactId>geronimo-jms_2.0_spec</artifactId>
       </dependency>
       <dependency>
          <groupId>org.jboss.logging</groupId>

--- a/tests/joram-tests/pom.xml
+++ b/tests/joram-tests/pom.xml
@@ -84,8 +84,8 @@
          <artifactId>geronimo-jaspi</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.jboss.spec.javax.jms</groupId>
-         <artifactId>jboss-jms-api_2.0_spec</artifactId>
+         <groupId>org.apache.geronimo.specs</groupId>
+         <artifactId>geronimo-jms_2.0_spec</artifactId>
       </dependency>
    </dependencies>
 

--- a/tests/performance-tests/pom.xml
+++ b/tests/performance-tests/pom.xml
@@ -98,8 +98,8 @@
          <artifactId>geronimo-jaspi</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.jboss.spec.javax.jms</groupId>
-         <artifactId>jboss-jms-api_2.0_spec</artifactId>
+         <groupId>org.apache.geronimo.specs</groupId>
+         <artifactId>geronimo-jms_2.0_spec</artifactId>
       </dependency>
    </dependencies>
 

--- a/tests/soak-tests/pom.xml
+++ b/tests/soak-tests/pom.xml
@@ -117,8 +117,8 @@
          <artifactId>geronimo-jaspi</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.jboss.spec.javax.jms</groupId>
-         <artifactId>jboss-jms-api_2.0_spec</artifactId>
+         <groupId>org.apache.geronimo.specs</groupId>
+         <artifactId>geronimo-jms_2.0_spec</artifactId>
       </dependency>
    </dependencies>
 

--- a/tests/stress-tests/pom.xml
+++ b/tests/stress-tests/pom.xml
@@ -117,8 +117,8 @@
          <artifactId>geronimo-jaspi</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.jboss.spec.javax.jms</groupId>
-         <artifactId>jboss-jms-api_2.0_spec</artifactId>
+         <groupId>org.apache.geronimo.specs</groupId>
+         <artifactId>geronimo-jms_2.0_spec</artifactId>
       </dependency>
    </dependencies>
 

--- a/tests/timing-tests/pom.xml
+++ b/tests/timing-tests/pom.xml
@@ -95,8 +95,8 @@
          <artifactId>geronimo-jaspi</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.jboss.spec.javax.jms</groupId>
-         <artifactId>jboss-jms-api_2.0_spec</artifactId>
+         <groupId>org.apache.geronimo.specs</groupId>
+         <artifactId>geronimo-jms_2.0_spec</artifactId>
       </dependency>
    </dependencies>
 


### PR DESCRIPTION
Geronimo now has a JMS 2 spec jar published.  I've updated the ActiveMQ 6 code base to point to it.  You were also missing apache parent, which is a requirement for apache maven based projects.