### PR TITLE
ACTIVEMQ6-64 Messages duplicated during ScaleDown or queue.totalIterator()

### DIFF
--- a/activemq-server/src/main/java/org/apache/activemq/core/paging/PageTransactionInfo.java
+++ b/activemq-server/src/main/java/org/apache/activemq/core/paging/PageTransactionInfo.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.core.paging;
 
 import org.apache.activemq.core.journal.EncodingSupport;
+import org.apache.activemq.core.paging.cursor.PageIterator;
 import org.apache.activemq.core.paging.cursor.PagePosition;
 import org.apache.activemq.core.paging.cursor.PageSubscription;
 import org.apache.activemq.core.persistence.StorageManager;
@@ -61,10 +62,8 @@ public interface PageTransactionInfo extends EncodingSupport
    /**
     * This method will hold the position to be delivered later in case this transaction is pending.
     * If the tx is not pending, it will return false, so the caller can deliver it right away
-    * @param cursor
-    * @param cursorPos
     * @return true if the message will be delivered later, false if it should be delivered right away
     */
-   boolean deliverAfterCommit(PageSubscription cursor, PagePosition cursorPos);
+   boolean deliverAfterCommit(PageIterator pageIterator, PageSubscription cursor, PagePosition cursorPos);
 
 }

--- a/activemq-server/src/main/java/org/apache/activemq/core/paging/cursor/PageIterator.java
+++ b/activemq-server/src/main/java/org/apache/activemq/core/paging/cursor/PageIterator.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.core.paging.cursor;
+
+import org.apache.activemq.utils.LinkedListIterator;
+
+/**
+ * @author clebertsuconic
+ */
+
+public interface PageIterator extends LinkedListIterator<PagedReference>
+{
+   void redeliver(PagePosition reference);
+}

--- a/activemq-server/src/main/java/org/apache/activemq/core/paging/cursor/PageSubscription.java
+++ b/activemq-server/src/main/java/org/apache/activemq/core/paging/cursor/PageSubscription.java
@@ -125,12 +125,12 @@ public interface PageSubscription
     * To be used on redeliveries
     * @param position
     */
-   void redeliver(PagePosition position);
+   void redeliver(PageIterator iterator, PagePosition position);
 
    void printDebug();
 
    /**
-    * @param minPage
+    * @param page
     * @return
     */
    boolean isComplete(long page);


### PR DESCRIPTION
The redelivery list was not isolated on the PageIterator. This is moving the
redelivery list to the Iterator so we would have proper isolation of the functionality.

The previous version was assuming a single instance of PageIterator, QueueImpl and PageSubscription.
When we started using more than one instance of the Iterator we created this bug.