### PR TITLE
Rework dependency management in top level poms

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,18 @@ of well formatted commit messages to the README.md.  This is required
 to enable developers to quickly identify what the commit is intended to 
 do and why the commit was added.
 ```
+### Adding New Dependencies
+
+Due to incompatibilities between some open source licenses and the Apache v2.0 license (that this project is licensed under)
+care must be taken when adding new dependencies to the project.  The Apache Software Foundation 3rd party
+ licensing policy has more information here: http://www.apache.org/legal/3party.html
+
+To keep track of all licenses in ActiveMQ6, new dependencies must be added in either the top level pom.xml or in test/pom.xml
+(depending on whether this is a test only dependency or if it is used in the main code base).  The dependency should be
+added under the dependency management section with version and labelled with a comment highlighting the license for the
+dependency version.  See existing dependencies in the main pom.xml for examples.  The dependency can then be added to
+individual ActiveMQ6 modules *without* the version specified (the version is implied from the dependency management
+section of the top level pom).  This allows ActiveMQ6 developers to keep track of all dependencies and licenses.
 
 ### Core Contributers
 

--- a/examples/jms/jms-bridge/pom.xml
+++ b/examples/jms/jms-bridge/pom.xml
@@ -44,10 +44,6 @@ under the License.
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.jboss.jbossts.jts</groupId>
-         <artifactId>jbossjts-jacorb</artifactId>
-      </dependency>
-      <dependency>
          <groupId>org.apache.geronimo.specs</groupId>
          <artifactId>geronimo-jms_2.0_spec</artifactId>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -175,238 +175,240 @@
 
    <dependencyManagement>
       <dependencies>
-         <!--
-            JBoss Tools
-         -->
+         <!-- ## Documentation Build Dependencies ## -->
+         <dependency>
+            <groupId>org.jboss.apiviz</groupId>
+            <artifactId>apiviz</artifactId>
+            <version>1.3.2.GA</version>
+            <scope>release</scope>
+            <!-- License: LGPL -->
+         </dependency>
+         <!-- ## End Documentation Build Dependencies ## -->
+
+         <!-- ## Test Dependenices ## Note: Junit is required in certain module tests.  We should control versions from here. -->
+         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+            <!-- License: CPL 1.0 -->
+            <!-- There are newer versions of the JUnit but they break our tests -->
+         </dependency>
+         <!-- ## End Test Dependencies ## -->
+
+         <!-- ### Build Time Dependencies ### -->
          <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
             <version>1.2.0.Final</version>
-            <scope>provided</scope>
-         </dependency>
-
-         <!--
-             JBoss Logging
-         -->
-         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <version>3.1.4.GA</version>
-         </dependency>
-
-         <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>jboss-logmanager</artifactId>
-            <version>1.5.1.Final</version>
-         </dependency>
-
-         <dependency>
-            <groupId>net.java.dev.javacc</groupId>
-            <artifactId>javacc</artifactId>
-            <version>4.0</version>
-         </dependency>
-
-         <!-- needed to compile JMS-->
-         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jms_2.0_spec</artifactId>
-            <version>${geronimo.jms.2.spec.version}</version>
-         </dependency>
-
-         <!-- needed to provide JMS injection-->
-         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <version>1.0-SP4</version>
-         </dependency>
-         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
-         </dependency>
-
-         <!-- needed to compile JavaEE examples-->
-         <dependency>
-             <groupId>org.apache.geronimo.specs</groupId>
-             <artifactId>geronimo-ejb_3.0_spec</artifactId>
-             <version>1.0.1</version>
-	      </dependency>
-         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jta_1.1_spec</artifactId>
-            <version>1.1.1</version>
-         </dependency>
-
-         <!--this for xa recovery-->
-         <dependency>
-            <groupId>org.jboss.jbossts.jts</groupId>
-            <artifactId>jbossjts-jacorb</artifactId>
-            <version>4.17.13.Final</version>
-         </dependency>
-         <!--needed to compile security-->
-         <dependency>
-            <groupId>org.jboss.security</groupId>
-            <artifactId>jboss-security-spi</artifactId>
-            <version>2.0.3.SP1</version>
-         </dependency>
-         <dependency>
-            <groupId>org.jboss.security</groupId>
-            <artifactId>jbosssx</artifactId>
-            <version>2.0.3.SP1</version>
-         </dependency>
-         <!--needed to compile the bootstrap jar-->
-         <dependency>
-            <groupId>org.jgroups</groupId>
-            <artifactId>jgroups</artifactId>
-            <version>3.6.0.Final</version>
-         </dependency>
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>airline</artifactId>
-            <version>0.6</version>
-        </dependency>
-         <!--needed to compile transport jar-->
-         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-            <version>${netty.version}</version>
+            <scope>compile</scope>
+            <!-- License: LGPL-->
          </dependency>
          <!--needed to compile the logging jar-->
          <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>1.2.16</version>
+            <scope>compile</scope>
+            <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-spi</artifactId>
             <version>2.1.0.GA</version>
+            <scope>compile</scope>
+            <!-- License: LGPL-->
+         </dependency>
+         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>3.1.4.RELEASE</version>
+            <scope>compile</scope>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <version>3.1.4.RELEASE</version>
+            <scope>compile</scope>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>3.1.4.RELEASE</version>
+            <scope>compile</scope>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jms</artifactId>
+            <version>3.1.4.RELEASE</version>
+            <scope>compile</scope>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <!-- ### End Build Time Dependencies ### -->
+
+         <!-- ### Run Time Dependencies: MUST NOT INCLUDE CAT X LICENSES ###-->
+         <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.1.4.GA</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <version>1.5.1.Final</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>net.java.dev.javacc</groupId>
+            <artifactId>javacc</artifactId>
+            <version>4.0</version>
+            <!-- License: BSD -->
+         </dependency>
+         <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jms_2.0_spec</artifactId>
+            <version>${geronimo.jms.2.spec.version}</version>
+            <!-- License: Apache 2.0 -->
          </dependency>
 
+         <!-- Required for: JMS Injection -->
+         <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>1.0-SP4</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <!-- End JMS Injection -->
+
+         <!-- ## Examples Dependencies ## -->
+         <dependency>
+             <groupId>org.apache.geronimo.specs</groupId>
+             <artifactId>geronimo-ejb_3.0_spec</artifactId>
+             <version>1.0.1</version>
+             <!-- License: Apache 2.0 -->
+	      </dependency>
+         <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jta_1.1_spec</artifactId>
+            <version>1.1.1</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <!-- ## End Examples Dependencies ## -->
+
+         <!--needed to compile the bootstrap jar-->
+         <dependency>
+            <groupId>org.jgroups</groupId>
+            <artifactId>jgroups</artifactId>
+            <version>3.6.0.Final</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>airline</artifactId>
+            <version>0.6</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <!--needed to compile transport jar-->
+         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>${netty.version}</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
          <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>proton-j</artifactId>
             <version>0.8</version>
+            <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>proton-jms</artifactId>
             <version>0.8</version>
+            <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-client</artifactId>
             <version>5.10.0</version>
+            <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
            <groupId>org.slf4j</groupId>
            <artifactId>slf4j-api</artifactId>
            <version>1.7.5</version>
+           <!-- License: MIT -->
          </dependency>
 
-         <!--needed to compile the spring support-->
-         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>3.0.3.RELEASE</version>
-         </dependency>
-         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-            <version>3.0.3.RELEASE</version>
-         </dependency>
-         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>3.0.3.RELEASE</version>
-         </dependency>
-         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-jms</artifactId>
-            <version>3.0.3.RELEASE</version>
-         </dependency>
          <!--needed for the rest support-->
          <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
             <version>${resteasy.version}</version>
+            <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
             <version>${resteasy.version}</version>
+            <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson-provider</artifactId>
             <version>${resteasy.version}</version>
+            <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-atom-provider</artifactId>
             <version>${resteasy.version}</version>
+            <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>tjws</artifactId>
             <version>${resteasy.version}</version>
+            <!-- License: Apache 2.0 -->
          </dependency>
-         <!-- needed for jetty web support-->
+
+         <!-- ## Jetty web Dependencies ##-->
          <dependency>
             <groupId>org.eclipse.jetty.aggregate</groupId>
             <artifactId>jetty-all-server</artifactId>
             <version>7.6.9.v20130131</version>
+            <!-- License: (Joint): Apache 2.0 & EPL 1.0 -->
         </dependency>
         <dependency>
            <groupId>org.apache.geronimo.specs</groupId>
            <artifactId>geronimo-servlet_3.0_spec</artifactId>
            <version>1.0</version>
+           <!-- License: Apache 2.0 -->
         </dependency>
         <dependency>
            <groupId>org.jolokia</groupId>
            <artifactId>jolokia-war</artifactId>
            <type>war</type>
            <version>1.2.3</version>
+           <!-- License: Apache 2.0 -->
         </dependency>
-         <!-- needed to compile the tests -->
-         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <!-- There are newer versions of the JUnit but they break our tests -->
-            <version>4.11</version>
-         </dependency>
-
-         <!--needed to compile the jms tests -->
-         <dependency>
-	         <groupId>org.apache.geronimo.components</groupId>
-	         <artifactId>geronimo-jaspi</artifactId>
-	         <version>2.0.0</version>
-         </dependency>
-
-         <!--needed to run the jms tests -->
-         <dependency>
-            <groupId>apache-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <version>1.1.0.jboss</version>
-         </dependency>
-
-         <!-- needed for javaee examples-->
-         <dependency>
-            <groupId>org.jboss.ejb3</groupId>
-            <artifactId>jboss-ejb3-ext-api</artifactId>
-            <version>1.0.0</version>
-         </dependency>
+         <!-- ## End Jetty Wed Dependencies ## -->
 
          <dependency>
-         <groupId>org.apache.geronimo.specs</groupId>
+            <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
             <version>2.0.0</version>
-         </dependency>
-         <!-- needed for javadoc graphics-->
-         <dependency>
-            <groupId>org.jboss.apiviz</groupId>
-            <artifactId>apiviz</artifactId>
-            <version>1.3.2.GA</version>
+            <!-- License: Apache 2.0 -->
          </dependency>
       </dependencies>
    </dependencyManagement>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -21,9 +21,9 @@
       <artifactId>activemq-pom</artifactId>
       <version>6.0.0-SNAPSHOT</version>
    </parent>
+
    <name>ActiveMQ6 Tests POM</name>
    <modelVersion>4.0.0</modelVersion>
-
    <groupId>org.apache.activemq.tests</groupId>
    <artifactId>activemq-tests-pom</artifactId>
    <packaging>pom</packaging>
@@ -31,6 +31,49 @@
    <properties>
       <activemq.basedir>${project.basedir}/..</activemq.basedir>
    </properties>
+
+   <dependencyManagement>
+      <dependencies>
+         <!-- ## XA Dependencies ## -->
+         <dependency>
+            <groupId>org.jboss.jbossts.jts</groupId>
+            <artifactId>jbossjts-jacorb</artifactId>
+            <version>4.17.13.Final</version>
+            <!-- License: LGPL -->
+         </dependency>
+         <!-- ## End XA Dependencies ## -->
+
+         <!--## Security Dependencies ## -->
+         <dependency>
+            <groupId>org.jboss.security</groupId>
+            <artifactId>jboss-security-spi</artifactId>
+            <version>2.0.3.SP1</version>
+            <!-- License: LGPL -->
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.security</groupId>
+            <artifactId>jbosssx</artifactId>
+            <version>2.0.3.SP1</version>
+            <!-- License: LGPL -->
+         </dependency>
+         <!-- ## End Security Dependencies ## -->
+
+         <!--## JMS Dependencies ## -->
+         <dependency>
+            <groupId>org.apache.geronimo.components</groupId>
+            <artifactId>geronimo-jaspi</artifactId>
+            <version>2.0.0</version>
+            <!-- License: Apache: 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>apache-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.1.0.jboss</version>
+            <!-- License: Apache: 2.0 -->
+         </dependency>
+         <!-- End JMS Dependencies -->
+      </dependencies>
+   </dependencyManagement>
 
    <build>
       <plugins>

--- a/tests/unit-tests/pom.xml
+++ b/tests/unit-tests/pom.xml
@@ -81,7 +81,6 @@
       <dependency>
          <groupId>org.jboss.security</groupId>
          <artifactId>jbosssx</artifactId>
-         <version>2.0.3.SP1</version>
       </dependency>
       <dependency>
          <groupId>junit</groupId>


### PR DESCRIPTION
This patch moves test dependencies into out of the main pom and into the
tests module pom.  This will make managing 3rd party category X
dependencies much easier going forward.  In addition each dependency
license has been outlined in the pom and README entry added to outline
future policy when adding 3rd party depdendencies.