### PR TITLE
A few more excludes for RAT plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -923,6 +923,8 @@
                   <exclude>**/*.lock</exclude>
                   <exclude>**/META-INF/services/*</exclude>
                   <exclude>**/*.iml</exclude>
+                  <exclude>**/*.jceks</exclude>
+                  <exclude>**/*.jks</exclude>
                </excludes>
             </configuration>
             <executions>


### PR DESCRIPTION
These are necessary because for some reason the Apache CI build doesn't recognize all the keystores as binary and it's choking on them.