### PR TITLE
Only check TM exists for JMSBridge with ONCE_ONLY

### DIFF
--- a/activemq-jms-server/src/main/java/org/apache/activemq/jms/bridge/impl/JMSBridgeImpl.java
+++ b/activemq-jms-server/src/main/java/org/apache/activemq/jms/bridge/impl/JMSBridgeImpl.java
@@ -406,8 +406,7 @@ public final class JMSBridgeImpl implements JMSBridge
       boolean ok;
 
       // Check to see if the QoSMode requires a TM
-      if (qualityOfServiceMode.equals(QualityOfServiceMode.AT_MOST_ONCE) ||
-         qualityOfServiceMode.equals(QualityOfServiceMode.ONCE_AND_ONLY_ONCE))
+      if (qualityOfServiceMode.equals(QualityOfServiceMode.ONCE_AND_ONLY_ONCE) && sourceCff != targetCff)
       {
          if (tm == null)
          {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/jms/bridge/JMSBridgeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/jms/bridge/JMSBridgeTest.java
@@ -39,7 +39,9 @@ import org.apache.activemq.jms.bridge.ConnectionFactoryFactory;
 import org.apache.activemq.jms.bridge.QualityOfServiceMode;
 import org.apache.activemq.jms.bridge.impl.JMSBridgeImpl;
 import org.apache.activemq.jms.client.ActiveMQMessage;
+import org.apache.activemq.service.extensions.ServiceUtils;
 import org.apache.activemq.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.tests.integration.ra.DummyTransactionManager;
 import org.apache.activemq.utils.DefaultSensitiveStringCodec;
 import org.junit.Assert;
 import org.junit.Test;
@@ -407,7 +409,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     null,
                                     false);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.start();
 
@@ -447,6 +448,7 @@ public class JMSBridgeTest extends BridgeTestBase
          checkAllMessageReceivedInOrder(cf1, targetQueue, NUM_MESSAGES, 1, false);
 
          checkAllMessageReceivedInOrder(cf1, targetQueue, 0, NUM_MESSAGES - 1, false);
+
       }
       finally
       {
@@ -759,7 +761,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     null,
                                     false);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.start();
 
@@ -848,7 +849,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     null,
                                     false);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.start();
 
@@ -936,7 +936,6 @@ public class JMSBridgeTest extends BridgeTestBase
          bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory,
                                     targetQueueFactory, "guest", mask, "guest", mask, null, 5000,
                                     10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.setUseMaskedPassword(true);
 
@@ -1023,7 +1022,6 @@ public class JMSBridgeTest extends BridgeTestBase
          bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory,
                                     targetQueueFactory, "guest", mask, "guest", mask, null, 5000,
                                     10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.setUseMaskedPassword(true);
          bridge.setPasswordCodec(codec.getClass().getName() + ";key=bridgekey");
@@ -1138,7 +1136,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     null,
                                     false);
-         bridge.setTransactionManager(mgr);
          bridge.start();
 
          sendMessages(cf0, sourceTopic, 0, NUM_MESSAGES, false, largeMessage);
@@ -1214,7 +1211,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     null,
                                     false);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.start();
 
@@ -1268,7 +1264,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     "subTest",
                                     "clientid123",
                                     false);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.start();
 
@@ -1333,7 +1328,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     null,
                                     on);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.start();
 
@@ -1541,7 +1535,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     null,
                                     messageIDInHeader);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.start();
 
@@ -1716,7 +1709,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     null,
                                     false);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.start();
 
@@ -1802,6 +1794,7 @@ public class JMSBridgeTest extends BridgeTestBase
       {
          factInUse0 = cff0xa;
          factInUse1 = cff1xa;
+         ServiceUtils.setTransactionManager(newTransactionManager());
       }
 
       try
@@ -1823,7 +1816,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     null,
                                     false);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.start();
 
@@ -1896,6 +1888,7 @@ public class JMSBridgeTest extends BridgeTestBase
       {
          factInUse0 = cff0xa;
          factInUse1 = cff1xa;
+         ServiceUtils.setTransactionManager(newTransactionManager());
       }
 
       try
@@ -1917,7 +1910,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     null,
                                     false);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.start();
 
@@ -2010,7 +2002,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     null,
                                     false);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.start();
 
@@ -2079,6 +2070,7 @@ public class JMSBridgeTest extends BridgeTestBase
       {
          factInUse0 = cff0xa;
          factInUse1 = cff1xa;
+         ServiceUtils.setTransactionManager(newTransactionManager());
       }
       try
       {
@@ -2101,7 +2093,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     null,
                                     false);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.start();
 
@@ -2155,6 +2146,7 @@ public class JMSBridgeTest extends BridgeTestBase
       if (qosMode.equals(QualityOfServiceMode.ONCE_AND_ONLY_ONCE))
       {
          factInUse0 = cff0xa;
+         ServiceUtils.setTransactionManager(newTransactionManager());
       }
 
       try
@@ -2178,7 +2170,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     null,
                                     false);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.start();
 
@@ -2233,6 +2224,7 @@ public class JMSBridgeTest extends BridgeTestBase
       {
          factInUse0 = cff0xa;
          factInUse1 = cff1xa;
+         ServiceUtils.setTransactionManager(newTransactionManager());
       }
 
       try
@@ -2258,7 +2250,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     null,
                                     false);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.start();
 
@@ -2293,6 +2284,7 @@ public class JMSBridgeTest extends BridgeTestBase
       if (qosMode.equals(QualityOfServiceMode.ONCE_AND_ONLY_ONCE))
       {
          factInUse0 = cff0xa;
+         ServiceUtils.setTransactionManager(newTransactionManager());
       }
 
       try
@@ -2318,7 +2310,6 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     null,
                                     false);
-         bridge.setTransactionManager(newTransactionManager());
 
          bridge.start();
 
@@ -2350,8 +2341,9 @@ public class JMSBridgeTest extends BridgeTestBase
    @Test
    public void testSetTMClass() throws Exception
    {
-      JMSBridgeImpl bridge = null;
+      TransactionManagerLocatorImpl.tm = new DummyTransactionManager();
 
+      JMSBridgeImpl bridge = null;
       try
       {
          bridge = new JMSBridgeImpl(cff0,
@@ -2365,7 +2357,7 @@ public class JMSBridgeTest extends BridgeTestBase
                                     null,
                                     3000,
                                     10,
-                                    QualityOfServiceMode.AT_MOST_ONCE,
+                                    QualityOfServiceMode.ONCE_AND_ONLY_ONCE,
                                     10000,
                                     3000,
                                     null,
@@ -2421,7 +2413,6 @@ public class JMSBridgeTest extends BridgeTestBase
       return newTransactionManager();
    }
 
-
    // Inner classes -------------------------------------------------------------------
 
    private static class StressSender implements Runnable
@@ -2455,5 +2446,4 @@ public class JMSBridgeTest extends BridgeTestBase
       }
 
    }
-
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/jms/bridge/TransactionManagerLocatorImpl.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/jms/bridge/TransactionManagerLocatorImpl.java
@@ -19,7 +19,6 @@ package org.apache.activemq.tests.integration.jms.bridge;
 
 import javax.transaction.TransactionManager;
 
-import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple;
 import org.apache.activemq.service.extensions.transactions.TransactionManagerLocator;
 
 /**
@@ -28,11 +27,16 @@ import org.apache.activemq.service.extensions.transactions.TransactionManagerLoc
 
 public class TransactionManagerLocatorImpl implements TransactionManagerLocator
 {
-   public static TransactionManager tm = new TransactionManagerImple();
+   public static TransactionManager tm = null;
 
    @Override
    public TransactionManager getTransactionManager()
    {
       return tm;
+   }
+
+   public void setTransactionManager(TransactionManager transactionManager)
+   {
+      tm = transactionManager;
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/util/JMSTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/util/JMSTestBase.java
@@ -46,6 +46,7 @@ import org.apache.activemq.jms.server.config.ConnectionFactoryConfiguration;
 import org.apache.activemq.jms.server.config.impl.ConnectionFactoryConfigurationImpl;
 import org.apache.activemq.jms.server.impl.JMSServerManagerImpl;
 import org.apache.activemq.service.extensions.ServiceUtils;
+import org.apache.activemq.tests.integration.jms.bridge.TransactionManagerLocatorImpl;
 import org.apache.activemq.tests.integration.ra.DummyTransactionManager;
 import org.apache.activemq.tests.unit.util.InVMNamingContext;
 import org.junit.After;
@@ -59,7 +60,6 @@ import org.junit.Before;
  */
 public class JMSTestBase extends ServiceTestBase
 {
-
    protected ActiveMQServer server;
 
    protected JMSServerManagerImpl jmsServer;
@@ -153,9 +153,6 @@ public class JMSTestBase extends ServiceTestBase
    {
       super.setUp();
 
-      // Load Arjuna TM if one is not already set.
-      if (ServiceUtils.getTransactionManager() == null) useRealTransactionManager();
-
       mbeanServer = MBeanServerFactory.createMBeanServer();
 
       Configuration conf = createDefaultConfig(true)
@@ -236,6 +233,9 @@ public class JMSTestBase extends ServiceTestBase
       MBeanServerFactory.releaseMBeanServer(mbeanServer);
 
       mbeanServer = null;
+
+      TransactionManagerLocatorImpl.tm = null;
+      ServiceUtils.setTransactionManager(null);
 
       super.tearDown();
    }
@@ -331,4 +331,5 @@ public class JMSTestBase extends ServiceTestBase
          throw new JMSRuntimeException(cause.getMessage(), cause.getErrorCode(), cause);
       }
    }
+
 }


### PR DESCRIPTION
A transaction manager is only required on the JMSBridge when the QoS
level is set to ONCE_AND_ONCE_ONLY.  Previous to the this patch it was
also checking for a TM on the AT_MOST_ONCE QoS level.  This patch also
ensures that the TM is set to null after each test run.