### PR TITLE
give receiver a bit more time on bridge test

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/cluster/bridge/BridgeStartTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/cluster/bridge/BridgeStartTest.java
@@ -587,7 +587,7 @@ public class BridgeStartTest extends ServiceTestBase
 
          for (int i = 0; i < numMessages; i++)
          {
-            ClientMessage message = consumer1.receive(1000);
+            ClientMessage message = consumer1.receive(3000);
 
             Assert.assertNotNull(message);
 


### PR DESCRIPTION
This is to address this failure: https://builds.apache.org/job/ActiveMQ6-Nightly-Regression-Test/29/testReport/junit/org.apache.activemq.tests.integration.cluster.bridge/BridgeStartTest/testTargetServerNotAvailableNoReconnectTries_isNetty_true_/.

I was able to reproduce the failure locally before the fix, but unable to reproduce the failure (even after several hundred runs) after the fix.