### PR TITLE
Rename Connector class on NodeUp for HQ clients

### DIFF
--- a/activemq-core-client/src/main/java/org/apache/activemq/core/protocol/core/impl/BackwardsCompatibilityUtils.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/core/protocol/core/impl/BackwardsCompatibilityUtils.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.core.protocol.core.impl;
+
+import org.apache.activemq.api.core.Pair;
+import org.apache.activemq.api.core.TransportConfiguration;
+import org.apache.activemq.api.core.client.TopologyMember;
+
+/**
+ * This is a utility class to house any HornetQ client specific backwards compatibility methods.
+ *
+ * @author mtaylor
+ */
+
+public class BackwardsCompatibilityUtils
+{
+   private static int INITIAL_ACTIVEMQ_INCREMENTING_VERSION = 126;
+
+   public static Pair<TransportConfiguration, TransportConfiguration> getTCPair(int clientIncrementingVersion, TopologyMember member)
+   {
+      if (clientIncrementingVersion < INITIAL_ACTIVEMQ_INCREMENTING_VERSION)
+      {
+         return new Pair<>(replaceClassName(member.getLive()), replaceClassName(member.getBackup()));
+      }
+      return new Pair<>(member.getLive(), member.getBackup());
+   }
+
+   private static TransportConfiguration replaceClassName(TransportConfiguration tc)
+   {
+      if (tc != null)
+      {
+         String className = tc.getFactoryClassName().replace("org.apache.activemq", "org.hornetq").replace("ActiveMQ", "HornetQ");
+         return new TransportConfiguration(className, tc.getParams(), tc.getName());
+      }
+      return tc;
+   }
+}

--- a/activemq-server/src/main/java/org/apache/activemq/core/protocol/core/impl/CoreProtocolManager.java
+++ b/activemq-server/src/main/java/org/apache/activemq/core/protocol/core/impl/CoreProtocolManager.java
@@ -234,9 +234,9 @@ class CoreProtocolManager implements ProtocolManager
                {
                   try
                   {
-                     final Pair<TransportConfiguration, TransportConfiguration> connectorPair =
-                        new Pair<TransportConfiguration, TransportConfiguration>(topologyMember.getLive(),
-                                                                                 topologyMember.getBackup());
+                     final Pair<TransportConfiguration, TransportConfiguration> connectorPair = BackwardsCompatibilityUtils
+                        .getTCPair(channel0.getConnection().getClientVersion(), topologyMember);
+
                      final String nodeID = topologyMember.getNodeId();
                      // Using an executor as most of the notifications on the Topology
                      // may come from a channel itself


### PR DESCRIPTION
To support HornetQ clients we must pass back HornetQ connector factory
names. Currently the connector factory name returned as part of node up
broadcast group (after initial client connection and client sends suscribe
topology packet) is what ever the server is configured to use in its
cluster discovery.  Since the server has now been repackaged to
org.apache.activemq, the older HornetQ clients can not find the
connector factory class on it's class path.  To get around this problem
the server now checks the version of the client and if the client is
HornetQ the server renames the to org.hornetq and returns before sending
to the client.