### PR TITLE
Add apache parent to main pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,16 @@
    <artifactId>activemq-pom</artifactId>
    <packaging>pom</packaging>
    <version>6.0.0-SNAPSHOT</version>
+
+   <parent>
+      <groupId>org.apache</groupId>
+      <artifactId>apache</artifactId>
+      <version>16</version>
+   </parent>
+
    <modules>
       <module>activemq-protocols</module>
-     <module>activemq-dto</module>
+      <module>activemq-dto</module>
    </modules>
 
    <name>ActiveMQ6 Parent</name>


### PR DESCRIPTION
We should be using the Apache parent pom in our project.  This will give us a bunch of default apache configurations such as repositories, release set up and so on.  If we have any issues using the pom we should try to fix them rather than remove the parent.