### PR TITLE
repo work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -432,38 +432,6 @@
       </dependencies>
    </dependencyManagement>
 
-   <repositories>
-      <repository>
-         <snapshots>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-         </snapshots>
-         <releases>
-            <enabled>true</enabled>
-            <updatePolicy>interval:10080</updatePolicy>
-         </releases>
-         <id>jboss.release</id>
-         <name>JBoss releases</name>
-         <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      </repository>
-   </repositories>
-   <pluginRepositories>
-      <pluginRepository>
-         <snapshots>
-            <enabled>false</enabled>
-            <updatePolicy>never</updatePolicy>
-         </snapshots>
-         <releases>
-            <enabled>true</enabled>
-            <updatePolicy>interval:10080</updatePolicy>
-         </releases>
-         <id>jboss.release</id>
-         <name>JBoss releases</name>
-         <url>https://repository.jboss.org/nexus/content/groups/public</url>
-      </pluginRepository>
-   </pluginRepositories>
-
-
    <profiles>
       <profile>
          <id>default</id>

--- a/tests/byteman-tests/pom.xml
+++ b/tests/byteman-tests/pom.xml
@@ -127,15 +127,7 @@
          <artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jboss-security-spi</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jbosssx</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>apache-logging</groupId>
+         <groupId>commons-logging</groupId>
          <artifactId>commons-logging</artifactId>
       </dependency>
       <dependency>

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -132,14 +132,6 @@
          <artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jboss-security-spi</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jbosssx</artifactId>
-      </dependency>
-      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
       </dependency>

--- a/tests/jms-tests/pom.xml
+++ b/tests/jms-tests/pom.xml
@@ -83,19 +83,11 @@
          <artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jboss-security-spi</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jbosssx</artifactId>
-      </dependency>
-      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
       </dependency>
       <dependency>
-         <groupId>apache-logging</groupId>
+         <groupId>commons-logging</groupId>
          <artifactId>commons-logging</artifactId>
       </dependency>
       <dependency>

--- a/tests/joram-tests/pom.xml
+++ b/tests/joram-tests/pom.xml
@@ -55,19 +55,11 @@
          <artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jboss-security-spi</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jbosssx</artifactId>
-      </dependency>
-      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
       </dependency>
       <dependency>
-         <groupId>apache-logging</groupId>
+         <groupId>commons-logging</groupId>
          <artifactId>commons-logging</artifactId>
       </dependency>
       <dependency>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -43,21 +43,6 @@
          </dependency>
          <!-- ## End XA Dependencies ## -->
 
-         <!--## Security Dependencies ## -->
-         <dependency>
-            <groupId>org.jboss.security</groupId>
-            <artifactId>jboss-security-spi</artifactId>
-            <version>2.0.3.SP1</version>
-            <!-- License: LGPL -->
-         </dependency>
-         <dependency>
-            <groupId>org.jboss.security</groupId>
-            <artifactId>jbosssx</artifactId>
-            <version>2.0.3.SP1</version>
-            <!-- License: LGPL -->
-         </dependency>
-         <!-- ## End Security Dependencies ## -->
-
          <!--## JMS Dependencies ## -->
          <dependency>
             <groupId>org.apache.geronimo.components</groupId>
@@ -66,9 +51,9 @@
             <!-- License: Apache: 2.0 -->
          </dependency>
          <dependency>
-            <groupId>apache-logging</groupId>
+            <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.1.0.jboss</version>
+            <version>1.2</version>
             <!-- License: Apache: 2.0 -->
          </dependency>
          <!-- End JMS Dependencies -->

--- a/tests/soak-tests/pom.xml
+++ b/tests/soak-tests/pom.xml
@@ -88,19 +88,11 @@
          <artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jboss-security-spi</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jbosssx</artifactId>
-      </dependency>
-      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
       </dependency>
       <dependency>
-         <groupId>apache-logging</groupId>
+         <groupId>commons-logging</groupId>
          <artifactId>commons-logging</artifactId>
       </dependency>
       <dependency>

--- a/tests/stress-tests/pom.xml
+++ b/tests/stress-tests/pom.xml
@@ -88,19 +88,11 @@
          <artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jboss-security-spi</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jbosssx</artifactId>
-      </dependency>
-      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
       </dependency>
       <dependency>
-         <groupId>apache-logging</groupId>
+         <groupId>commons-logging</groupId>
          <artifactId>commons-logging</artifactId>
       </dependency>
       <dependency>

--- a/tests/timing-tests/pom.xml
+++ b/tests/timing-tests/pom.xml
@@ -70,14 +70,6 @@
          <artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jboss-security-spi</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jbosssx</artifactId>
-      </dependency>
-      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
       </dependency>

--- a/tests/unit-tests/pom.xml
+++ b/tests/unit-tests/pom.xml
@@ -71,18 +71,6 @@
          <artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jboss-security-spi</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jbosssx</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.jboss.security</groupId>
-         <artifactId>jbosssx</artifactId>
-      </dependency>
-      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
       </dependency>


### PR DESCRIPTION
Remove the reference to the JBoss Maven repo, and make all the necessary adjustments on the child-projects.  It turns out we don't even need the security dependencies in the tests.