### PR TITLE
Remove servlet api dep from rest module

### DIFF
--- a/activemq-rest/pom.xml
+++ b/activemq-rest/pom.xml
@@ -97,11 +97,6 @@
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
       </dependency>
-      <dependency>
-         <groupId>javax.servlet</groupId>
-         <artifactId>servlet-api</artifactId>
-         <version>2.5</version>
-      </dependency>
    </dependencies>
 
    <build>


### PR DESCRIPTION
This is not required.  Builds fine and tests pass without this dep.