### PR TITLE
ACTIVEMQ6-80 - update acceptor config to use URI's

### DIFF
--- a/activemq-commons/src/main/java/org/apache/activemq/utils/uri/URIFactory.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/utils/uri/URIFactory.java
@@ -25,12 +25,12 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * @author clebertsuconic
  */
-public class URIFactory<T>
+public class URIFactory<T, P>
 {
 
    private URI defaultURI;
 
-   private final Map<String, URISchema<T>> schemas = new ConcurrentHashMap<>();
+   private final Map<String, URISchema<T, P>> schemas = new ConcurrentHashMap<>();
 
    public URI getDefaultURI()
    {
@@ -42,7 +42,7 @@ public class URIFactory<T>
       this.defaultURI = uri;
    }
 
-   public void registerSchema(URISchema<T> schemaFactory)
+   public void registerSchema(URISchema<T, P> schemaFactory)
    {
       schemas.put(schemaFactory.getSchemaName(), schemaFactory);
       schemaFactory.setFactory(this);
@@ -53,23 +53,14 @@ public class URIFactory<T>
       schemas.remove(schemaName);
    }
 
-   public T newObject(String uriString) throws Exception
+   public URI expandURI(String uriString) throws Exception
    {
-      URI uri = normalise(uriString);
-      URISchema<T> schemaFactory = schemas.get(uri.getScheme());
-
-      if (schemaFactory == null)
-      {
-         throw new NullPointerException("Schema " + uri.getScheme() + " not found");
-      }
-
-
-      return schemaFactory.newObject(uri);
+      return normalise(uriString);
    }
 
-   public T newObject(URI uri) throws Exception
+   public T newObject(URI uri, P param) throws Exception
    {
-      URISchema<T> schemaFactory = schemas.get(uri.getScheme());
+      URISchema<T, P> schemaFactory = schemas.get(uri.getScheme());
 
       if (schemaFactory == null)
       {
@@ -77,12 +68,12 @@ public class URIFactory<T>
       }
 
 
-      return schemaFactory.newObject(uri);
+      return schemaFactory.newObject(uri, param);
    }
 
    public void populateObject(URI uri, T bean) throws Exception
    {
-      URISchema<T> schemaFactory = schemas.get(uri.getScheme());
+      URISchema<T, P> schemaFactory = schemas.get(uri.getScheme());
 
       if (schemaFactory == null)
       {
@@ -94,7 +85,7 @@ public class URIFactory<T>
 
    public URI createSchema(String scheme, T bean) throws Exception
    {
-      URISchema<T> schemaFactory = schemas.get(scheme);
+      URISchema<T, P> schemaFactory = schemas.get(scheme);
 
       if (schemaFactory == null)
       {
@@ -144,8 +135,8 @@ public class URIFactory<T>
                builder.append(connectorURIS[i]);
             }
          }
-         return new URI(builder.toString());
+         return new URI(builder.toString().replace(";", "&"));
       }
-      return new URI(uri);
+      return new URI(uri.replace(";", "&"));
    }
 }

--- a/activemq-commons/src/main/java/org/apache/activemq/utils/uri/URISchema.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/utils/uri/URISchema.java
@@ -33,13 +33,13 @@ import org.apache.commons.beanutils.FluentPropertyBeanIntrospector;
  * @author clebertsuconic
  */
 
-public abstract class URISchema<T>
+public abstract class URISchema<T, P>
 {
    public abstract String getSchemaName();
 
-   public T newObject(URI uri) throws Exception
+   public T newObject(URI uri, P param) throws Exception
    {
-      return newObject(uri, null);
+      return newObject(uri, null, param);
    }
 
    public void populateObject(URI uri, T bean) throws Exception
@@ -52,15 +52,15 @@ public abstract class URISchema<T>
       return internalNewURI(bean);
    }
 
-   private URIFactory<T> parentFactory;
+   private URIFactory<T, P> parentFactory;
 
 
-   void setFactory(URIFactory<T> factory)
+   void setFactory(URIFactory<T, P> factory)
    {
       this.parentFactory = parentFactory;
    }
 
-   protected URIFactory<T> getFactory()
+   protected URIFactory<T, P> getFactory()
    {
       return parentFactory;
    }
@@ -78,7 +78,7 @@ public abstract class URISchema<T>
 
    protected URI getDefaultURI()
    {
-      URIFactory<T> factory = getFactory();
+      URIFactory<T, P> factory = getFactory();
       if (factory == null)
       {
          return null;
@@ -107,12 +107,12 @@ public abstract class URISchema<T>
     * @return
     * @throws Exception
     */
-   public T newObject(URI uri, Map<String, String> propertyOverrides) throws Exception
+   public  T newObject(URI uri, Map<String, String> propertyOverrides, P param) throws Exception
    {
-      return internalNewObject(uri, parseQuery(uri.getQuery(), propertyOverrides));
+      return internalNewObject(uri, parseQuery(uri.getQuery(), propertyOverrides), param);
    }
 
-   protected abstract T internalNewObject(URI uri, Map<String, String> query) throws Exception;
+   protected abstract T internalNewObject(URI uri, Map<String, String> query, P param) throws Exception;
 
    protected abstract URI internalNewURI(T bean) throws Exception;
 
@@ -204,15 +204,15 @@ public abstract class URISchema<T>
    {
       if (allowableProperties.contains("host"))
       {
-         properties.put("host", uri.getHost());
+         properties.put("host", "" + uri.getHost());
       }
       if (allowableProperties.contains("port"))
       {
-         properties.put("port", uri.getPort());
+         properties.put("port", "" + uri.getPort());
       }
       if (allowableProperties.contains("userInfo"))
       {
-         properties.put("userInfo", uri.getUserInfo());
+         properties.put("userInfo", "" + uri.getUserInfo());
       }
       for (Map.Entry<String, String> entry : query.entrySet())
       {

--- a/activemq-commons/src/test/java/org/apache/activemq/utils/URIParserTest.java
+++ b/activemq-commons/src/test/java/org/apache/activemq/utils/URIParserTest.java
@@ -41,7 +41,7 @@ public class URIParserTest
    public void testSchemaFruit() throws Throwable
    {
       FruitParser parser = new FruitParser();
-      Fruit fruit = (Fruit)parser.newObject(new URI("fruit://some:guy@fair-market:3030?color=green&fluentName=something"));
+      Fruit fruit = (Fruit)parser.newObject(new URI("fruit://some:guy@fair-market:3030?color=green&fluentName=something"), null);
 
       Assert.assertEquals("fruit", fruit.getName());
       Assert.assertEquals(3030, fruit.getPort());
@@ -62,7 +62,7 @@ public class URIParserTest
    public void testSchemaNoHosPropertyt() throws Throwable
    {
       FruitParser parser = new FruitParser();
-      FruitBase fruit = parser.newObject(new URI("base://some:guy@fair-market:3030?color=green&fluentName=something"));
+      FruitBase fruit = parser.newObject(new URI("base://some:guy@fair-market:3030?color=green&fluentName=something"), null);
       Assert.assertEquals("base", fruit.getName());
       Assert.assertEquals("green", fruit.getColor());
       Assert.assertEquals("something", fruit.getFluentName());
@@ -77,7 +77,7 @@ public class URIParserTest
    public void testSchemaNoHostOnURL() throws Throwable
    {
       FruitParser parser = new FruitParser();
-      Fruit fruit = (Fruit)parser.newObject(new URI("fruit://some:guy@port?color=green&fluentName=something"));
+      Fruit fruit = (Fruit)parser.newObject(new URI("fruit://some:guy@port?color=green&fluentName=something"), null);
 
       System.out.println("fruit:" + fruit);
       Assert.assertEquals("fruit", fruit.getName());
@@ -86,7 +86,7 @@ public class URIParserTest
    }
 
 
-   class FruitParser extends URIFactory<FruitBase>
+   class FruitParser extends URIFactory<FruitBase, String>
    {
       FruitParser()
       {
@@ -95,7 +95,7 @@ public class URIParserTest
       }
    }
 
-   class FruitSchema extends URISchema<FruitBase>
+   class FruitSchema extends URISchema<FruitBase, String>
    {
       @Override
       public String getSchemaName()
@@ -105,7 +105,7 @@ public class URIParserTest
 
 
       @Override
-      public FruitBase internalNewObject(URI uri, Map<String, String> query) throws Exception
+      public FruitBase internalNewObject(URI uri, Map<String, String> query, String fruitName) throws Exception
       {
          return setData(uri, new Fruit(getSchemaName()), query);
       }
@@ -117,7 +117,7 @@ public class URIParserTest
       }
    }
 
-   class FruitBaseSchema extends URISchema<FruitBase>
+   class FruitBaseSchema extends URISchema<FruitBase, String>
    {
       @Override
       public String getSchemaName()
@@ -127,7 +127,7 @@ public class URIParserTest
 
 
       @Override
-      public FruitBase internalNewObject(URI uri, Map<String, String> query) throws Exception
+      public FruitBase internalNewObject(URI uri, Map<String, String> query, String fruitName) throws Exception
       {
          return setData(uri, new FruitBase(getSchemaName()), query);
       }

--- a/activemq-core-client/src/main/java/org/apache/activemq/api/core/client/ActiveMQClient.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/api/core/client/ActiveMQClient.java
@@ -123,7 +123,7 @@ public final class ActiveMQClient
    public static ServerLocator createServerLocator(final String url) throws Exception
    {
       ServerLocatorParser parser = new ServerLocatorParser();
-      return parser.newObject(new URI(url));
+      return parser.newObject(new URI(url), null);
    }
 
    /**

--- a/activemq-core-client/src/main/java/org/apache/activemq/core/remoting/impl/netty/TransportConstants.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/core/remoting/impl/netty/TransportConstants.java
@@ -187,7 +187,7 @@ public class TransportConstants
 
    public static final Set<String> ALLOWABLE_ACCEPTOR_KEYS;
 
-   public static final String CONNECTION_TTL = "connection-ttl";
+   public static final String CONNECTION_TTL = "connectionTtl";
 
    public static final String STOMP_ENABLE_MESSAGE_ID = "stomp-enable-message-id";
 

--- a/activemq-core-client/src/main/java/org/apache/activemq/uri/AbstractServerLocatorSchema.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/uri/AbstractServerLocatorSchema.java
@@ -25,8 +25,9 @@ import java.util.Map;
 /**
  * @author <a href="mailto:andy.taylor@jboss.org">Andy Taylor</a>
  */
-public abstract class AbstractServerLocatorSchema extends URISchema<ServerLocator>
+public abstract class AbstractServerLocatorSchema extends URISchema<ServerLocator, String>
 {
+
    protected ConnectionOptions newConnectionOptions(URI uri, Map<String, String> query) throws Exception
    {
       return setData(uri, new ConnectionOptions(), query);

--- a/activemq-core-client/src/main/java/org/apache/activemq/uri/AbstractTransportConfigurationSchema.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/uri/AbstractTransportConfigurationSchema.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.uri;
+
+import org.apache.activemq.api.core.TransportConfiguration;
+import org.apache.activemq.utils.uri.URISchema;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:andy.taylor@jboss.org">Andy Taylor</a>
+ */
+public abstract class AbstractTransportConfigurationSchema  extends URISchema<List<TransportConfiguration>, String>
+{
+}

--- a/activemq-core-client/src/main/java/org/apache/activemq/uri/ConnectorTransportConfigurationParser.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/uri/ConnectorTransportConfigurationParser.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.uri;
+
+import org.apache.activemq.api.core.TransportConfiguration;
+import org.apache.activemq.core.remoting.impl.netty.TransportConstants;
+import org.apache.activemq.utils.uri.URIFactory;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:andy.taylor@jboss.org">Andy Taylor</a>
+ */
+public class ConnectorTransportConfigurationParser extends URIFactory<List<TransportConfiguration>, String>
+{
+   public ConnectorTransportConfigurationParser()
+   {
+      registerSchema(new TCPTransportConfigurationSchema(TransportConstants.ALLOWABLE_CONNECTOR_KEYS));
+      registerSchema(new InVMTransportConfigurationSchema());
+   }
+}

--- a/activemq-core-client/src/main/java/org/apache/activemq/uri/InVMServerLocatorSchema.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/uri/InVMServerLocatorSchema.java
@@ -24,7 +24,6 @@ import org.apache.activemq.utils.uri.URISchema;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -39,19 +38,14 @@ public class InVMServerLocatorSchema extends AbstractServerLocatorSchema
    }
 
    @Override
-   protected ServerLocator internalNewObject(URI uri, Map<String, String> query) throws Exception
+   protected ServerLocator internalNewObject(URI uri, Map<String, String> query, String name) throws Exception
    {
-      TransportConfiguration tc = createTransportConfiguration(uri);
+      TransportConfiguration tc = InVMTransportConfigurationSchema.createTransportConfiguration(uri, name, "org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory");
       ServerLocator factory = ActiveMQClient.createServerLocatorWithoutHA(tc);
       return URISchema.setData(uri, factory, query);
    }
 
-   public static TransportConfiguration createTransportConfiguration(URI uri)
-   {
-      Map<String, Object> inVmTransportConfig = new HashMap<>();
-      inVmTransportConfig.put("serverId", uri.getHost());
-      return new TransportConfiguration("org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory", inVmTransportConfig);
-   }
+
 
    @Override
    protected URI internalNewURI(ServerLocator bean) throws Exception

--- a/activemq-core-client/src/main/java/org/apache/activemq/uri/InVMTransportConfigurationSchema.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/uri/InVMTransportConfigurationSchema.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.uri;
+
+import org.apache.activemq.api.core.TransportConfiguration;
+import org.apache.activemq.utils.uri.SchemaConstants;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:andy.taylor@jboss.org">Andy Taylor</a>
+ */
+public class InVMTransportConfigurationSchema extends AbstractTransportConfigurationSchema
+{
+   @Override
+   public String getSchemaName()
+   {
+      return SchemaConstants.VM;
+   }
+
+   @Override
+   protected List<TransportConfiguration> internalNewObject(URI uri, Map<String, String> query, String name) throws Exception
+   {
+      List<TransportConfiguration> configurations = new ArrayList<>();
+      configurations.add(createTransportConfiguration(uri, name, getFactoryName()));
+      return configurations;
+   }
+
+   @Override
+   protected URI internalNewURI(List<TransportConfiguration> bean) throws Exception
+   {
+      return null;
+   }
+
+   protected String getFactoryName()
+   {
+      return "org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory";
+   }
+
+   public static TransportConfiguration createTransportConfiguration(URI uri, String name, String factoryName)
+   {
+      Map<String, Object> inVmTransportConfig = new HashMap<>();
+      inVmTransportConfig.put("serverId", uri.getHost());
+      return new TransportConfiguration(factoryName, inVmTransportConfig, name);
+   }
+}

--- a/activemq-core-client/src/main/java/org/apache/activemq/uri/JGroupsServerLocatorSchema.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/uri/JGroupsServerLocatorSchema.java
@@ -41,11 +41,11 @@ public class JGroupsServerLocatorSchema extends AbstractServerLocatorSchema
    }
 
    @Override
-   protected ServerLocator internalNewObject(URI uri, Map<String, String> query) throws Exception
+   protected ServerLocator internalNewObject(URI uri, Map<String, String> query, String name) throws Exception
    {
       ConnectionOptions options = newConnectionOptions(uri, query);
 
-      DiscoveryGroupConfiguration dcConfig = getDiscoveryGroupConfiguration(uri, query);
+      DiscoveryGroupConfiguration dcConfig = getDiscoveryGroupConfiguration(uri, query, name);
 
       if (options.isHa())
       {
@@ -80,7 +80,7 @@ public class JGroupsServerLocatorSchema extends AbstractServerLocatorSchema
       return new URI(SchemaConstants.JGROUPS, null,  auth, -1, null, query, null);
    }
 
-   public static DiscoveryGroupConfiguration getDiscoveryGroupConfiguration(URI uri, Map<String, String> query) throws Exception
+   public static DiscoveryGroupConfiguration getDiscoveryGroupConfiguration(URI uri, Map<String, String> query, String name) throws Exception
    {
       BroadcastEndpointFactory endpointFactory;
       if (query.containsKey("file"))
@@ -94,7 +94,7 @@ public class JGroupsServerLocatorSchema extends AbstractServerLocatorSchema
 
       URISchema.setData(uri, endpointFactory, query);
 
-      DiscoveryGroupConfiguration dcConfig = new DiscoveryGroupConfiguration().setBroadcastEndpointFactory(endpointFactory);
+      DiscoveryGroupConfiguration dcConfig = new DiscoveryGroupConfiguration().setName(name).setBroadcastEndpointFactory(endpointFactory);
 
       URISchema.setData(uri, dcConfig, query);
       return dcConfig;

--- a/activemq-core-client/src/main/java/org/apache/activemq/uri/ServerLocatorParser.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/uri/ServerLocatorParser.java
@@ -22,7 +22,7 @@ import org.apache.activemq.utils.uri.URIFactory;
 /**
  * @author <a href="mailto:andy.taylor@jboss.org">Andy Taylor</a>
  */
-public class ServerLocatorParser extends URIFactory<ServerLocator>
+public class ServerLocatorParser extends URIFactory<ServerLocator, String>
 {
    public ServerLocatorParser()
    {

--- a/activemq-core-client/src/main/java/org/apache/activemq/uri/TCPTransportConfigurationSchema.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/uri/TCPTransportConfigurationSchema.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.uri;
+
+import org.apache.activemq.api.core.TransportConfiguration;
+import org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory;
+import org.apache.activemq.utils.uri.SchemaConstants;
+import org.apache.activemq.utils.uri.URISchema;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:andy.taylor@jboss.org">Andy Taylor</a>
+ */
+public class TCPTransportConfigurationSchema extends AbstractTransportConfigurationSchema
+{
+   private final Set<String> allowableProperties;
+
+   public TCPTransportConfigurationSchema(Set<String> allowableProperties)
+   {
+      this.allowableProperties = allowableProperties;
+   }
+
+   @Override
+   public String getSchemaName()
+   {
+      return SchemaConstants.TCP;
+   }
+
+   @Override
+   protected List<TransportConfiguration> internalNewObject(URI uri, Map<String, String> query, String name) throws Exception
+   {
+      return getTransportConfigurations(uri, query, allowableProperties, name, getFactoryName());
+   }
+
+   @Override
+   protected URI internalNewURI(List<TransportConfiguration> bean) throws Exception
+   {
+      return null;
+   }
+
+   public static List<TransportConfiguration> getTransportConfigurations(URI uri, Map<String, String> query, Set<String> allowableProperties, String name, String factoryName) throws URISyntaxException
+   {
+      HashMap<String, Object> props = new HashMap<>();
+
+      URISchema.setData(uri, props, allowableProperties, query);
+      List<TransportConfiguration> transportConfigurations = new ArrayList<>();
+
+      transportConfigurations.add(new TransportConfiguration(factoryName,
+                                                             props,
+                                                             name));
+      String connectors = uri.getFragment();
+
+      if (connectors != null)
+      {
+         String[] split = connectors.split(",");
+         for (String s : split)
+         {
+            URI extraUri = new URI(s);
+            HashMap<String, Object> newProps = new HashMap<>();
+            URISchema.setData(extraUri, newProps, allowableProperties, query);
+            URISchema.setData(extraUri, newProps, allowableProperties, URISchema.parseQuery(extraUri.getQuery(), null));
+            transportConfigurations.add(new TransportConfiguration(factoryName,
+                                                                   newProps,
+                                                                   name + ":" + extraUri.toString()));
+         }
+      }
+      return transportConfigurations;
+   }
+
+   protected String getFactoryName()
+   {
+      return NettyConnectorFactory.class.getName();
+   }
+}

--- a/activemq-core-client/src/main/java/org/apache/activemq/uri/UDPServerLocatorSchema.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/uri/UDPServerLocatorSchema.java
@@ -46,11 +46,11 @@ public class UDPServerLocatorSchema extends AbstractServerLocatorSchema
    }
 
    @Override
-   protected ServerLocator internalNewObject(URI uri, Map<String, String> query) throws Exception
+   protected ServerLocator internalNewObject(URI uri, Map<String, String> query, String name) throws Exception
    {
       ConnectionOptions options = newConnectionOptions(uri, query);
 
-      DiscoveryGroupConfiguration dgc = getDiscoveryGroupConfiguration(uri, query, getHost(uri), getPort(uri));
+      DiscoveryGroupConfiguration dgc = getDiscoveryGroupConfiguration(uri, query, getHost(uri), getPort(uri), name);
 
       if (options.isHa())
       {
@@ -72,7 +72,7 @@ public class UDPServerLocatorSchema extends AbstractServerLocatorSchema
       return new URI(SchemaConstants.UDP, null,  endpoint.getGroupAddress(), endpoint.getGroupPort(), null, query, null);
    }
 
-   public static DiscoveryGroupConfiguration getDiscoveryGroupConfiguration(URI uri, Map<String, String> query, String host, int port) throws Exception
+   public static DiscoveryGroupConfiguration getDiscoveryGroupConfiguration(URI uri, Map<String, String> query, String host, int port, String name) throws Exception
    {
       UDPBroadcastEndpointFactory endpointFactoryConfiguration = new UDPBroadcastEndpointFactory()
                .setGroupAddress(host)
@@ -81,6 +81,7 @@ public class UDPServerLocatorSchema extends AbstractServerLocatorSchema
       URISchema.setData(uri, endpointFactoryConfiguration, query);
 
       DiscoveryGroupConfiguration dgc = URISchema.setData(uri, new DiscoveryGroupConfiguration(), query)
+            .setName(name)
          .setBroadcastEndpointFactory(endpointFactoryConfiguration);
 
       URISchema.setData(uri, dgc, query);

--- a/activemq-jms-client/src/main/java/org/apache/activemq/api/jms/ActiveMQJMSClient.java
+++ b/activemq-jms-client/src/main/java/org/apache/activemq/api/jms/ActiveMQJMSClient.java
@@ -31,8 +31,6 @@ import org.apache.activemq.jms.client.ActiveMQXAQueueConnectionFactory;
 import org.apache.activemq.jms.client.ActiveMQXATopicConnectionFactory;
 import org.apache.activemq.uri.ConnectionFactoryParser;
 
-import java.net.URI;
-
 /**
  * A utility class for creating ActiveMQ client-side JMS managed resources.
  *
@@ -45,10 +43,10 @@ public class ActiveMQJMSClient
     *
     * @return the ActiveMQConnectionFactory
     */
-   public static ActiveMQConnectionFactory createConnectionFactory(final String url) throws Exception
+   public static ActiveMQConnectionFactory createConnectionFactory(final String url, String name) throws Exception
    {
       ConnectionFactoryParser parser = new ConnectionFactoryParser();
-      return parser.newObject(new URI(url));
+      return parser.newObject(parser.expandURI(url), name);
    }
 
    /**

--- a/activemq-jms-client/src/main/java/org/apache/activemq/jms/client/ActiveMQConnectionFactory.java
+++ b/activemq-jms-client/src/main/java/org/apache/activemq/jms/client/ActiveMQConnectionFactory.java
@@ -112,7 +112,7 @@ public class ActiveMQConnectionFactory implements Externalizable, Referenceable,
       try
       {
          URI uri = new URI(url);
-         serverLocator = locatorParser.newObject(uri);
+         serverLocator = locatorParser.newObject(uri, null);
          parser.populateObject(uri, this);
       }
       catch (Exception e)

--- a/activemq-jms-client/src/main/java/org/apache/activemq/jndi/ActiveMQInitialContextFactory.java
+++ b/activemq-jms-client/src/main/java/org/apache/activemq/jndi/ActiveMQInitialContextFactory.java
@@ -60,7 +60,7 @@ public class ActiveMQInitialContextFactory implements InitialContextFactory
             String jndiName = key.substring(connectionFactoryPrefix.length());
             try
             {
-               ActiveMQConnectionFactory factory = createConnectionFactory((String) environment.get(key));
+               ActiveMQConnectionFactory factory = createConnectionFactory((String) environment.get(key), jndiName);
                data.put(jndiName, factory);
             }
             catch (Exception e)
@@ -175,9 +175,9 @@ public class ActiveMQInitialContextFactory implements InitialContextFactory
    /**
     * Factory method to create a new connection factory from the given environment
     */
-   protected ActiveMQConnectionFactory createConnectionFactory(String uri) throws Exception
+   protected ActiveMQConnectionFactory createConnectionFactory(String uri, String name) throws Exception
    {
       ConnectionFactoryParser parser = new ConnectionFactoryParser();
-      return parser.newObject(uri);
+      return parser.newObject(parser.expandURI(uri), name);
    }
 }

--- a/activemq-jms-client/src/main/java/org/apache/activemq/uri/AbstractCFSchema.java
+++ b/activemq-jms-client/src/main/java/org/apache/activemq/uri/AbstractCFSchema.java
@@ -28,7 +28,7 @@ import org.apache.activemq.utils.uri.URISchema;
  * @author clebertsuconic
  */
 
-public abstract class AbstractCFSchema extends URISchema<ActiveMQConnectionFactory>
+public abstract class AbstractCFSchema extends URISchema<ActiveMQConnectionFactory, String>
 {
 
    protected JMSConnectionOptions newConectionOptions(URI uri, Map<String, String> query) throws Exception

--- a/activemq-jms-client/src/main/java/org/apache/activemq/uri/ConnectionFactoryParser.java
+++ b/activemq-jms-client/src/main/java/org/apache/activemq/uri/ConnectionFactoryParser.java
@@ -24,7 +24,7 @@ import org.apache.activemq.utils.uri.URIFactory;
  * @author clebertsuconic
  */
 
-public class ConnectionFactoryParser extends URIFactory<ActiveMQConnectionFactory>
+public class ConnectionFactoryParser extends URIFactory<ActiveMQConnectionFactory, String>
 {
    public ConnectionFactoryParser()
    {

--- a/activemq-jms-client/src/main/java/org/apache/activemq/uri/InVMSchema.java
+++ b/activemq-jms-client/src/main/java/org/apache/activemq/uri/InVMSchema.java
@@ -36,10 +36,12 @@ public class InVMSchema extends AbstractCFSchema
    }
 
    @Override
-   protected ActiveMQConnectionFactory internalNewObject(URI uri, Map<String, String> query) throws Exception
+   protected ActiveMQConnectionFactory internalNewObject(URI uri, Map<String, String> query, String name) throws Exception
    {
       JMSConnectionOptions options = newConectionOptions(uri, query);
-      ActiveMQConnectionFactory factory = ActiveMQJMSClient.createConnectionFactoryWithoutHA(options.getFactoryTypeEnum(), InVMServerLocatorSchema.createTransportConfiguration(uri));
+      ActiveMQConnectionFactory factory =
+            ActiveMQJMSClient.createConnectionFactoryWithoutHA(options.getFactoryTypeEnum(),
+                                                               InVMTransportConfigurationSchema.createTransportConfiguration(uri, name, "org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory"));
       return URISchema.setData(uri, factory, query);
    }
 

--- a/activemq-jms-client/src/main/java/org/apache/activemq/uri/JGroupsSchema.java
+++ b/activemq-jms-client/src/main/java/org/apache/activemq/uri/JGroupsSchema.java
@@ -43,11 +43,11 @@ public class JGroupsSchema extends AbstractCFSchema
    }
 
    @Override
-   public ActiveMQConnectionFactory internalNewObject(URI uri, Map<String, String> query) throws Exception
+   public ActiveMQConnectionFactory internalNewObject(URI uri, Map<String, String> query, String name) throws Exception
    {
       JMSConnectionOptions options = newConectionOptions(uri, query);
 
-      DiscoveryGroupConfiguration dcConfig = JGroupsServerLocatorSchema.getDiscoveryGroupConfiguration(uri, query);
+      DiscoveryGroupConfiguration dcConfig = JGroupsServerLocatorSchema.getDiscoveryGroupConfiguration(uri, query, name);
 
       ActiveMQConnectionFactory factory;
       if (options.isHa())

--- a/activemq-jms-client/src/main/java/org/apache/activemq/uri/UDPSchema.java
+++ b/activemq-jms-client/src/main/java/org/apache/activemq/uri/UDPSchema.java
@@ -40,11 +40,11 @@ public class UDPSchema extends AbstractCFSchema
    }
 
    @Override
-   public ActiveMQConnectionFactory internalNewObject(URI uri, Map<String, String> query) throws Exception
+   public ActiveMQConnectionFactory internalNewObject(URI uri, Map<String, String> query, String name) throws Exception
    {
       JMSConnectionOptions options = newConectionOptions(uri, query);
 
-      DiscoveryGroupConfiguration dgc = UDPServerLocatorSchema.getDiscoveryGroupConfiguration(uri, query, getHost(uri), getPort(uri));
+      DiscoveryGroupConfiguration dgc = UDPServerLocatorSchema.getDiscoveryGroupConfiguration(uri, query, getHost(uri), getPort(uri), name);
 
       ActiveMQConnectionFactory factory;
       if (options.isHa())

--- a/activemq-jms-client/src/test/java/org/apache/activemq/uri/ConnectionFactoryURITest.java
+++ b/activemq-jms-client/src/test/java/org/apache/activemq/uri/ConnectionFactoryURITest.java
@@ -56,7 +56,7 @@ public class ConnectionFactoryURITest
    @Test
    public void testQUEUE_XA_CF() throws Exception
    {
-      ActiveMQConnectionFactory factory = parser.newObject(new URI("tcp://localhost:3030?ha=true&type=QUEUE_XA_CF"));
+      ActiveMQConnectionFactory factory = parser.newObject(new URI("tcp://localhost:3030?ha=true&type=QUEUE_XA_CF"), null);
 
       Assert.assertTrue(ActiveMQXAQueueConnectionFactory.class.getName().equals(factory.getClass().getName()));
    }
@@ -64,7 +64,7 @@ public class ConnectionFactoryURITest
    @Test
    public void testTOPICXA_CF() throws Exception
    {
-      ActiveMQConnectionFactory factory = parser.newObject(new URI("tcp://localhost:3030?ha=true&type=TOPIC_XA_CF"));
+      ActiveMQConnectionFactory factory = parser.newObject(new URI("tcp://localhost:3030?ha=true&type=TOPIC_XA_CF"), null);
 
       Assert.assertTrue(ActiveMQXATopicConnectionFactory.class.getName().equals(factory.getClass().getName()));
    }
@@ -72,7 +72,7 @@ public class ConnectionFactoryURITest
 
    public void testQUEUE_CF() throws Exception
    {
-      ActiveMQConnectionFactory factory = parser.newObject(new URI("tcp://localhost:3030?ha=true&type=QUEUE_CF"));
+      ActiveMQConnectionFactory factory = parser.newObject(new URI("tcp://localhost:3030?ha=true&type=QUEUE_CF"), null);
 
       Assert.assertTrue(ActiveMQQueueConnectionFactory.class.getName().equals(factory.getClass().getName()));
    }
@@ -80,7 +80,7 @@ public class ConnectionFactoryURITest
    @Test
    public void testTOPIC_CF() throws Exception
    {
-      ActiveMQConnectionFactory factory = parser.newObject(new URI("tcp://localhost:3030?ha=true&type=TOPIC_CF"));
+      ActiveMQConnectionFactory factory = parser.newObject(new URI("tcp://localhost:3030?ha=true&type=TOPIC_CF"), null);
 
       Assert.assertTrue(ActiveMQTopicConnectionFactory.class.getName().equals(factory.getClass().getName()));
    }
@@ -88,7 +88,7 @@ public class ConnectionFactoryURITest
    @Test
    public void testCF() throws Exception
    {
-      ActiveMQConnectionFactory factory = parser.newObject(new URI("tcp://localhost:3030?ha=true&type=CF"));
+      ActiveMQConnectionFactory factory = parser.newObject(new URI("tcp://localhost:3030?ha=true&type=CF"), null);
 
       Assert.assertTrue(ActiveMQJMSConnectionFactory.class.getName().equals(factory.getClass().getName()));
    }
@@ -96,7 +96,7 @@ public class ConnectionFactoryURITest
    @Test
    public void testNoCF() throws Exception
    {
-      ActiveMQConnectionFactory factory = parser.newObject(new URI("tcp://localhost:3030?ha=true"));
+      ActiveMQConnectionFactory factory = parser.newObject(new URI("tcp://localhost:3030?ha=true"), null);
 
       Assert.assertTrue(ActiveMQJMSConnectionFactory.class.getName().equals(factory.getClass().getName()));
    }
@@ -109,7 +109,7 @@ public class ConnectionFactoryURITest
       BeanUtilsBean bean = new BeanUtilsBean();
       ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(true, (TransportConfiguration) null);
       populate(sb, bean, factory);
-      ActiveMQConnectionFactory factory2 = parser.newObject(new URI(sb.toString()));
+      ActiveMQConnectionFactory factory2 = parser.newObject(new URI(sb.toString()), null);
       checkEquals(bean, factory, factory2);
    }
 
@@ -121,11 +121,11 @@ public class ConnectionFactoryURITest
       StringBuilder sb = new StringBuilder();
       sb.append("tcp://localhost:3030?ha=true");
       populateConnectorParams(props, allowableConnectorKeys, sb);
-      ActiveMQConnectionFactory factory = parser.newObject(new URI(sb.toString()));
+      ActiveMQConnectionFactory factory = parser.newObject(new URI(sb.toString()), null);
 
       Map<String, Object> params = factory.getStaticConnectors()[0].getParams();
       Assert.assertEquals(params.get("host"), "localhost");
-      Assert.assertEquals(params.get("port"), 3030);
+      Assert.assertEquals(params.get("port"), "3030");
       for (Map.Entry<String, Object> entry : params.entrySet())
       {
          if (!entry.getKey().equals("host") && !entry.getKey().equals("port"))
@@ -152,7 +152,7 @@ public class ConnectionFactoryURITest
       populateConnectorParams(props3, allowableConnectorKeys, sb);
       sb.append(")?ha=true&clientID=myID");
 
-      ActiveMQConnectionFactory factory = parser.newObject(sb.toString());
+      ActiveMQConnectionFactory factory = parser.newObject(parser.expandURI((sb.toString())), null);
 
       TransportConfiguration[] staticConnectors = factory.getStaticConnectors();
       Assert.assertEquals(3, staticConnectors.length);
@@ -165,7 +165,7 @@ public class ConnectionFactoryURITest
    {
       TransportConfiguration connector = staticConnector;
       Assert.assertEquals(connector.getParams().get("host"), "localhost" + offfSet);
-      Assert.assertEquals(connector.getParams().get("port"), (5445 + offfSet));
+      Assert.assertEquals(connector.getParams().get("port"), "" + (5445 + offfSet));
       Map<String, Object> params = connector.getParams();
       for (Map.Entry<String, Object> entry : params.entrySet())
       {
@@ -203,7 +203,7 @@ public class ConnectionFactoryURITest
       TransportConfiguration tc3 = new TransportConfiguration(NettyConnectorFactory.class.getName(), params2);
       ActiveMQConnectionFactory connectionFactoryWithHA = ActiveMQJMSClient.createConnectionFactoryWithHA(JMSFactoryType.CF, tc, tc2, tc3);
       URI tcp = parser.createSchema("tcp", connectionFactoryWithHA);
-      ActiveMQConnectionFactory factory = parser.newObject(tcp);
+      ActiveMQConnectionFactory factory = parser.newObject(tcp, null);
       BeanUtilsBean bean = new BeanUtilsBean();
       checkEquals(bean, connectionFactoryWithHA, factory);
    }
@@ -211,7 +211,7 @@ public class ConnectionFactoryURITest
    @Test
    public void testUDP() throws Exception
    {
-      ActiveMQConnectionFactory factory = parser.newObject(new URI("udp://localhost:3030?ha=true&type=QUEUE_XA_CF"));
+      ActiveMQConnectionFactory factory = parser.newObject(new URI("udp://localhost:3030?ha=true&type=QUEUE_XA_CF"), null);
 
       Assert.assertTrue(ActiveMQXAQueueConnectionFactory.class.getName().equals(factory.getClass().getName()));
    }
@@ -224,7 +224,7 @@ public class ConnectionFactoryURITest
       BeanUtilsBean bean = new BeanUtilsBean();
       ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(true, (TransportConfiguration) null);
       populate(sb, bean, factory);
-      ActiveMQConnectionFactory factory2 = parser.newObject(new URI(sb.toString()));
+      ActiveMQConnectionFactory factory2 = parser.newObject(new URI(sb.toString()), null);
       checkEquals(bean, factory, factory2);
    }
 
@@ -240,7 +240,7 @@ public class ConnectionFactoryURITest
             .setBroadcastEndpointFactory(endpoint);
       ActiveMQConnectionFactory connectionFactoryWithHA = ActiveMQJMSClient.createConnectionFactoryWithHA(discoveryGroupConfiguration, JMSFactoryType.CF);
       URI tcp = parser.createSchema("udp", connectionFactoryWithHA);
-      ActiveMQConnectionFactory factory = parser.newObject(tcp);
+      ActiveMQConnectionFactory factory = parser.newObject(tcp, null);
       DiscoveryGroupConfiguration dgc = factory.getDiscoveryGroupConfiguration();
       Assert.assertNotNull(dgc);
       BroadcastEndpointFactory befc = dgc.getBroadcastEndpointFactory();
@@ -264,7 +264,7 @@ public class ConnectionFactoryURITest
    @Test
    public void testInvalidCFType() throws Exception
    {
-      ActiveMQConnectionFactory factory = parser.newObject(new URI("udp://localhost:3030?ha=true&type=QUEUE_XA_CFInvalid"));
+      ActiveMQConnectionFactory factory = parser.newObject(new URI("udp://localhost:3030?ha=true&type=QUEUE_XA_CFInvalid"), null);
 
       Assert.assertTrue(ActiveMQJMSConnectionFactory.class.getName().equals(factory.getClass().getName()));
    }
@@ -272,7 +272,7 @@ public class ConnectionFactoryURITest
    @Test
    public void testJGroupsFile() throws Exception
    {
-      ActiveMQConnectionFactory factory = parser.newObject(new URI("jgroups://channel-name?file=/path/to/some/file/channel-file.xml&test=33"));
+      ActiveMQConnectionFactory factory = parser.newObject(new URI("jgroups://channel-name?file=/path/to/some/file/channel-file.xml&test=33"), null);
 
       Assert.assertTrue(ActiveMQJMSConnectionFactory.class.getName().equals(factory.getClass().getName()));
       JGroupsFileBroadcastEndpointFactory broadcastEndpointFactory = (JGroupsFileBroadcastEndpointFactory) factory.getDiscoveryGroupConfiguration().getBroadcastEndpointFactory();
@@ -283,7 +283,7 @@ public class ConnectionFactoryURITest
    @Test
    public void testJGroupsKeyValue() throws Exception
    {
-      ActiveMQConnectionFactory factory = parser.newObject(new URI("jgroups://channel-name?properties=param=value;param2=value2&test=33"));
+      ActiveMQConnectionFactory factory = parser.newObject(new URI("jgroups://channel-name?properties=param=value;param2=value2&test=33"), null);
 
       Assert.assertTrue(ActiveMQJMSConnectionFactory.class.getName().equals(factory.getClass().getName()));
       JGroupsPropertiesBroadcastEndpointFactory broadcastEndpointFactory = (JGroupsPropertiesBroadcastEndpointFactory) factory.getDiscoveryGroupConfiguration().getBroadcastEndpointFactory();
@@ -299,7 +299,7 @@ public class ConnectionFactoryURITest
       BeanUtilsBean bean = new BeanUtilsBean();
       ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(true, (TransportConfiguration) null);
       populate(sb, bean, factory);
-      ActiveMQConnectionFactory factory2 = parser.newObject(new URI(sb.toString()));
+      ActiveMQConnectionFactory factory2 = parser.newObject(new URI(sb.toString()), null);
       checkEquals(bean, factory, factory2);
    }
 
@@ -317,7 +317,7 @@ public class ConnectionFactoryURITest
             .setBroadcastEndpointFactory(endpointFactory);
       ActiveMQConnectionFactory connectionFactoryWithHA = ActiveMQJMSClient.createConnectionFactoryWithHA(discoveryGroupConfiguration, JMSFactoryType.CF);
       URI tcp = parser.createSchema("jgroups", connectionFactoryWithHA);
-      ActiveMQConnectionFactory factory = parser.newObject(tcp);
+      ActiveMQConnectionFactory factory = parser.newObject(tcp, null);
       DiscoveryGroupConfiguration dgc = factory.getDiscoveryGroupConfiguration();
       Assert.assertNotNull(dgc);
       BroadcastEndpointFactory befc = dgc.getBroadcastEndpointFactory();
@@ -348,7 +348,7 @@ public class ConnectionFactoryURITest
             .setBroadcastEndpointFactory(endpointFactory);
       ActiveMQConnectionFactory connectionFactoryWithHA = ActiveMQJMSClient.createConnectionFactoryWithHA(discoveryGroupConfiguration, JMSFactoryType.CF);
       URI tcp = parser.createSchema("jgroups", connectionFactoryWithHA);
-      ActiveMQConnectionFactory factory = parser.newObject(tcp);
+      ActiveMQConnectionFactory factory = parser.newObject(tcp, null);
       DiscoveryGroupConfiguration dgc = factory.getDiscoveryGroupConfiguration();
       Assert.assertNotNull(dgc);
       BroadcastEndpointFactory broadcastEndpointFactory = dgc.getBroadcastEndpointFactory();

--- a/activemq-rest/src/test/resources/activemq-configuration.xml
+++ b/activemq-rest/src/test/resources/activemq-configuration.xml
@@ -28,15 +28,11 @@
        <!-- Connectors -->
 
        <connectors>
-           <connector name="in-vm">
-               <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory</factory-class>
-           </connector>
+           <connector name="in-vm">vm://0</connector>
        </connectors>
 
        <acceptors>
-           <acceptor name="in-vm">
-               <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>
-           </acceptor>
+           <acceptor name="in-vm">vm://0</acceptor>
        </acceptors>
 
        <!-- Other config -->

--- a/activemq-server/src/main/java/org/apache/activemq/uri/AcceptorTransportConfigurationParser.java
+++ b/activemq-server/src/main/java/org/apache/activemq/uri/AcceptorTransportConfigurationParser.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.uri;
+
+import org.apache.activemq.api.core.TransportConfiguration;
+import org.apache.activemq.core.remoting.impl.netty.TransportConstants;
+import org.apache.activemq.utils.uri.URIFactory;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:andy.taylor@jboss.org">Andy Taylor</a>
+ */
+public class AcceptorTransportConfigurationParser extends URIFactory<List<TransportConfiguration>, String>
+{
+   public AcceptorTransportConfigurationParser()
+   {
+      registerSchema(new TCPAcceptorTransportConfigurationSchema(TransportConstants.ALLOWABLE_ACCEPTOR_KEYS));
+      registerSchema(new InVMAcceptorTransportConfigurationSchema());
+   }
+}

--- a/activemq-server/src/main/java/org/apache/activemq/uri/InVMAcceptorTransportConfigurationSchema.java
+++ b/activemq-server/src/main/java/org/apache/activemq/uri/InVMAcceptorTransportConfigurationSchema.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.uri;
+
+import org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory;
+
+/**
+ * @author <a href="mailto:andy.taylor@jboss.org">Andy Taylor</a>
+ */
+public class InVMAcceptorTransportConfigurationSchema extends InVMTransportConfigurationSchema
+{
+   protected String getFactoryName()
+   {
+      return InVMAcceptorFactory.class.getName();
+   }
+}

--- a/activemq-server/src/main/java/org/apache/activemq/uri/TCPAcceptorTransportConfigurationSchema.java
+++ b/activemq-server/src/main/java/org/apache/activemq/uri/TCPAcceptorTransportConfigurationSchema.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.uri;
+
+import org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:andy.taylor@jboss.org">Andy Taylor</a>
+ */
+public class TCPAcceptorTransportConfigurationSchema extends TCPTransportConfigurationSchema
+{
+   public TCPAcceptorTransportConfigurationSchema(Set<String> allowableProperties)
+   {
+      super(allowableProperties);
+   }
+
+   public String getFactoryName()
+   {
+      return NettyAcceptorFactory.class.getName();
+   }
+}

--- a/activemq-server/src/main/resources/schema/activemq-configuration.xsd
+++ b/activemq-server/src/main/resources/schema/activemq-configuration.xsd
@@ -324,33 +324,7 @@
             </xsd:annotation>
             <xsd:complexType>
                <xsd:sequence>
-                  <xsd:element name="connector" maxOccurs="unbounded" minOccurs="0">
-                     <xsd:complexType>
-                        <xsd:sequence>
-                           <xsd:element maxOccurs="1" minOccurs="1" name="factory-class" type="xsd:string">
-                              <xsd:annotation>
-                                 <xsd:documentation>
-                                    Name of the ConnectorFactory implementation
-                                 </xsd:documentation>
-                              </xsd:annotation>
-                           </xsd:element>
-                           <xsd:element name="param" type="paramType" maxOccurs="unbounded" minOccurs="0">
-                              <xsd:annotation>
-                                 <xsd:documentation>
-                                    A key-value pair used to configure the connector. A connector can have many param's
-                                 </xsd:documentation>
-                              </xsd:annotation>
-                           </xsd:element>
-                        </xsd:sequence>
-                        <xsd:attribute name="name" type="xsd:ID" use="required">
-                           <xsd:annotation>
-                              <xsd:documentation>
-                                 Name of the connector
-                              </xsd:documentation>
-                           </xsd:annotation>
-                        </xsd:attribute>
-                     </xsd:complexType>
-                  </xsd:element>
+                  <xsd:element name="connector" type="transportType" maxOccurs="unbounded"/>
                </xsd:sequence>
             </xsd:complexType>
          </xsd:element>
@@ -363,33 +337,7 @@
             </xsd:annotation>
             <xsd:complexType>
                <xsd:sequence>
-                  <xsd:element name="acceptor" maxOccurs="unbounded" minOccurs="1">
-                     <xsd:complexType>
-                        <xsd:sequence>
-                           <xsd:element name="factory-class" type="xsd:string" maxOccurs="1" minOccurs="1">
-                              <xsd:annotation>
-                                 <xsd:documentation>
-                                    Name of the AcceptorFactory implementation
-                                 </xsd:documentation>
-                              </xsd:annotation>
-                           </xsd:element>
-                           <xsd:element name="param" type="paramType" maxOccurs="unbounded" minOccurs="0">
-                              <xsd:annotation>
-                                 <xsd:documentation>
-                                    A key-value pair used to configure the acceptor. An acceptor can have many param
-                                 </xsd:documentation>
-                              </xsd:annotation>
-                           </xsd:element>
-                        </xsd:sequence>
-                        <xsd:attribute name="name" type="xsd:string" use="optional">
-                           <xsd:annotation>
-                              <xsd:documentation>
-                                 Name of the acceptor
-                              </xsd:documentation>
-                           </xsd:annotation>
-                        </xsd:attribute>
-                     </xsd:complexType>
-                  </xsd:element>
+                  <xsd:element name="acceptor" type="transportType" maxOccurs="unbounded"/>
                </xsd:sequence>
             </xsd:complexType>
          </xsd:element>
@@ -2191,4 +2139,13 @@
          </xsd:annotation>
       </xsd:attribute>
    </xsd:complexType>
+
+   <xsd:complexType name="transportType">
+       <xsd:simpleContent>
+         <xsd:extension base="xsd:string">
+           <xsd:attribute name="name" type="xsd:string">
+           </xsd:attribute>
+         </xsd:extension>
+       </xsd:simpleContent>
+     </xsd:complexType>
 </xsd:schema>

--- a/activemq-server/src/test/java/org/apache/activemq/core/config/impl/FileConfigurationParserTest.java
+++ b/activemq-server/src/test/java/org/apache/activemq/core/config/impl/FileConfigurationParserTest.java
@@ -145,39 +145,14 @@ public class FileConfigurationParserTest extends UnitTestCase
          "<large-messages-directory>${jboss.server.data.dir}/activemq/largemessages</large-messages-directory>" + "\n" +
          "<paging-directory>${jboss.server.data.dir}/activemq/paging</paging-directory>" + "\n" +
          "<connectors>" + "\n" +
-         "<connector name=\"netty\">" + "\n" +
-         "<factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>" + "\n" +
-         "<param key=\"host\"  value=\"${jboss.bind.address:localhost}\"/>" + "\n" +
-         "<param key=\"port\"  value=\"${activemq.remoting.netty.port:5445}\"/>" + "\n" +
-         "</connector>" + "\n" +
-         "<connector name=\"netty-throughput\">" + "\n" +
-         "<factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>" + "\n" +
-         "<param key=\"host\"  value=\"${jboss.bind.address:localhost}\"/>" + "\n" +
-         "<param key=\"port\"  value=\"${activemq.remoting.netty.batch.port:5455}\"/>" + "\n" +
-         "<param key=\"batch-delay\" value=\"50\"/>" + "\n" +
-         "</connector>" + "\n" +
-         "<connector name=\"in-vm\">" + "\n" +
-         "<factory-class>org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory</factory-class>" + "\n" +
-         "<param key=\"server-id\" value=\"${activemq.server-id:0}\"/>" + "\n" +
-         "</connector>" + "\n" +
+         "<connector name=\"netty\">tcp://localhost:5445</connector>" + "\n" +
+         "<connector name=\"netty-throughput\">tcp://localhost:5545</connector>" + "\n" +
+         "<connector name=\"in-vm\">vm://0</connector>" + "\n" +
          "</connectors>" + "\n" +
          "<acceptors>" + "\n" +
-         "<acceptor name=\"netty\">" + "\n" +
-         "<factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>" + "\n" +
-         "<param key=\"host\"  value=\"${jboss.bind.address:localhost}\"/>" + "\n" +
-         "<param key=\"port\"  value=\"${activemq.remoting.netty.port:5445}\"/>" + "\n" +
-         "</acceptor>" + "\n" +
-         "<acceptor name=\"netty-throughput\">" + "\n" +
-         "<factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>" + "\n" +
-         "<param key=\"host\"  value=\"${jboss.bind.address:localhost}\"/>" + "\n" +
-         "<param key=\"port\"  value=\"${activemq.remoting.netty.batch.port:5455}\"/>" + "\n" +
-         "<param key=\"batch-delay\" value=\"50\"/>" + "\n" +
-         "<param key=\"direct-deliver\" value=\"false\"/>" + "\n" +
-         "</acceptor>" + "\n" +
-         "<acceptor name=\"in-vm\">" + "\n" +
-         "<factory-class>org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>" + "\n" +
-         "<param key=\"server-id\" value=\"0\"/>" + "\n" +
-         "</acceptor>" + "\n" +
+         "<acceptor name=\"netty\">tcp://localhost:5545</acceptor>" + "\n" +
+         "<acceptor name=\"netty-throughput\">tcp://localhost:5545</acceptor>" + "\n" +
+         "<acceptor name=\"in-vm\">vm://0</acceptor>" + "\n" +
          "</acceptors>" + "\n" +
          "<security-settings>" + "\n" +
          "<security-setting match=\"#\">" + "\n" +

--- a/activemq-server/src/test/java/org/apache/activemq/core/config/impl/FileConfigurationTest.java
+++ b/activemq-server/src/test/java/org/apache/activemq/core/config/impl/FileConfigurationTest.java
@@ -107,34 +107,30 @@ public class FileConfigurationTest extends ConfigurationImplTest
 
       TransportConfiguration tc = conf.getConnectorConfigurations().get("connector1");
       Assert.assertNotNull(tc);
-      Assert.assertEquals("org.apache.activemq.tests.unit.core.config.impl.TestConnectorFactory1", tc.getFactoryClassName());
-      Assert.assertEquals("v1", tc.getParams().get("a1"));
-      Assert.assertEquals("123", tc.getParams().get("a2"));
-      Assert.assertEquals("345", tc.getParams().get("a3"));
-      Assert.assertEquals("v4", tc.getParams().get("a4"));
+      Assert.assertEquals("org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory", tc.getFactoryClassName());
+      Assert.assertEquals("mylocal", tc.getParams().get("localAddress"));
+      Assert.assertEquals("99", tc.getParams().get("localPort"));
+      Assert.assertEquals("localhost1", tc.getParams().get("host"));
+      Assert.assertEquals("5678", tc.getParams().get("port"));
 
       tc = conf.getConnectorConfigurations().get("connector2");
       Assert.assertNotNull(tc);
-      Assert.assertEquals("org.apache.activemq.tests.unit.core.config.impl.TestConnectorFactory2", tc.getFactoryClassName());
-      Assert.assertEquals("w1", tc.getParams().get("b1"));
-      Assert.assertEquals("234", tc.getParams().get("b2"));
+      Assert.assertEquals("org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory", tc.getFactoryClassName());
+      Assert.assertEquals("5", tc.getParams().get("serverId"));
 
       Assert.assertEquals(2, conf.getAcceptorConfigurations().size());
       for (TransportConfiguration ac : conf.getAcceptorConfigurations())
       {
-         if (ac.getFactoryClassName().equals("org.apache.activemq.tests.unit.core.config.impl.TestAcceptorFactory1"))
+         if (ac.getFactoryClassName().equals("org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory"))
          {
-            Assert.assertEquals("org.apache.activemq.tests.unit.core.config.impl.TestAcceptorFactory1",
-                                ac.getFactoryClassName());
-            Assert.assertEquals("y1", ac.getParams().get("d1"));
-            Assert.assertEquals("456", ac.getParams().get("d2"));
+            Assert.assertEquals("456", ac.getParams().get("tcpNoDelay"));
+            Assert.assertEquals("44", ac.getParams().get("connectionTtl"));
          }
          else
          {
-            Assert.assertEquals("org.apache.activemq.tests.unit.core.config.impl.TestAcceptorFactory2",
+            Assert.assertEquals("org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory",
                                 ac.getFactoryClassName());
-            Assert.assertEquals("z1", ac.getParams().get("e1"));
-            Assert.assertEquals("567", ac.getParams().get("e2"));
+            Assert.assertEquals("0", ac.getParams().get("serverId"));
          }
       }
 

--- a/activemq-server/src/test/java/org/apache/activemq/core/config/impl/WrongRoleFileConfigurationParserTest.java
+++ b/activemq-server/src/test/java/org/apache/activemq/core/config/impl/WrongRoleFileConfigurationParserTest.java
@@ -75,39 +75,14 @@ public class WrongRoleFileConfigurationParserTest extends UnitTestCase
          "<large-messages-directory>${jboss.server.data.dir}/activemq/largemessages</large-messages-directory>" + "\n" +
          "<paging-directory>${jboss.server.data.dir}/activemq/paging</paging-directory>" + "\n" +
          "<connectors>" + "\n" +
-         "<connector name=\"netty\">" + "\n" +
-         "<factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>" + "\n" +
-         "<param key=\"host\"  value=\"${jboss.bind.address:localhost}\"/>" + "\n" +
-         "<param key=\"port\"  value=\"${activemq.remoting.netty.port:5445}\"/>" + "\n" +
-         "</connector>" + "\n" +
-         "<connector name=\"netty-throughput\">" + "\n" +
-         "<factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>" + "\n" +
-         "<param key=\"host\"  value=\"${jboss.bind.address:localhost}\"/>" + "\n" +
-         "<param key=\"port\"  value=\"${activemq.remoting.netty.batch.port:5455}\"/>" + "\n" +
-         "<param key=\"batch-delay\" value=\"50\"/>" + "\n" +
-         "</connector>" + "\n" +
-         "<connector name=\"in-vm\">" + "\n" +
-         "<factory-class>org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory</factory-class>" + "\n" +
-         "<param key=\"server-id\" value=\"${activemq.server-id:0}\"/>" + "\n" +
-         "</connector>" + "\n" +
+         "<connector name=\"netty\">tcp://localhost:5445</connector>" + "\n" +
+         "<connector name=\"netty-throughput\">tcp://localhost:5545</connector>" + "\n" +
+         "<connector name=\"in-vm\">vm://0</connector>" + "\n" +
          "</connectors>" + "\n" +
          "<acceptors>" + "\n" +
-         "<acceptor name=\"netty\">" + "\n" +
-         "<factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>" + "\n" +
-         "<param key=\"host\"  value=\"${jboss.bind.address:localhost}\"/>" + "\n" +
-         "<param key=\"port\"  value=\"${activemq.remoting.netty.port:5445}\"/>" + "\n" +
-         "</acceptor>" + "\n" +
-         "<acceptor name=\"netty-throughput\">" + "\n" +
-         "<factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>" + "\n" +
-         "<param key=\"host\"  value=\"${jboss.bind.address:localhost}\"/>" + "\n" +
-         "<param key=\"port\"  value=\"${activemq.remoting.netty.batch.port:5455}\"/>" + "\n" +
-         "<param key=\"batch-delay\" value=\"50\"/>" + "\n" +
-         "<param key=\"direct-deliver\" value=\"false\"/>" + "\n" +
-         "</acceptor>" + "\n" +
-         "<acceptor name=\"in-vm\">" + "\n" +
-         "<factory-class>org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>" + "\n" +
-         "<param key=\"server-id\" value=\"0\"/>" + "\n" +
-         "</acceptor>" + "\n" +
+         "<acceptor name=\"netty\">tcp://localhost:5545</acceptor>" + "\n" +
+         "<acceptor name=\"netty-throughput\">tcp://localhost:5545</acceptor>" + "\n" +
+         "<acceptor name=\"in-vm\">vm://0</acceptor>" + "\n" +
          "</acceptors>" + "\n" +
          "<security-settings>" + "\n" +
          "<security-setting match=\"#\">" + "\n" +

--- a/activemq-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/activemq-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -60,30 +60,12 @@
       </remoting-outgoing-interceptors>
       <persist-delivery-count-before-delivery>true</persist-delivery-count-before-delivery>
       <connectors>
-         <connector name="connector1">
-            <factory-class>org.apache.activemq.tests.unit.core.config.impl.TestConnectorFactory1</factory-class>
-            <param key="a1" value="v1"/>
-            <param key="a2" value="123"/>
-            <param key="a3" value="345"/>
-            <param key="a4" value="v4"/>
-         </connector>
-         <connector name="connector2">
-            <factory-class>org.apache.activemq.tests.unit.core.config.impl.TestConnectorFactory2</factory-class>
-            <param key="b1" value="w1"/>
-            <param key="b2" value="234"/>
-         </connector>
+         <connector name="connector1">tcp://localhost1:5678?localAddress=mylocal;localPort=99</connector>
+         <connector name="connector2">vm://5</connector>
       </connectors>
       <acceptors>
-         <acceptor name="acceptor1">
-            <factory-class>org.apache.activemq.tests.unit.core.config.impl.TestAcceptorFactory1</factory-class>
-            <param key="d1" value="y1"/>
-            <param key="d2" value="456"/>
-         </acceptor>
-   	     <acceptor name="acceptor2">
-   	        <factory-class>org.apache.activemq.tests.unit.core.config.impl.TestAcceptorFactory2</factory-class>
-   	        <param key="e1" value="z1"/>
-   	        <param key="e2" value="567"/>
-   	     </acceptor>
+         <acceptor>tcp://0.0.0.0:5445?tcpNoDelay=456;connectionTtl=44</acceptor>
+   	   <acceptor>vm://0?e1=z1;e2=567</acceptor>
       </acceptors>
       <broadcast-groups>
 	     <broadcast-group name="bg1">

--- a/distribution/activemq/pom.xml
+++ b/distribution/activemq/pom.xml
@@ -165,6 +165,14 @@
           <artifactId>jolokia-war</artifactId>
           <type>war</type>
        </dependency>
+      <dependency>
+         <groupId>commons-beanutils</groupId>
+         <artifactId>commons-beanutils</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>commons-logging</groupId>
+         <artifactId>commons-logging</artifactId>
+      </dependency>
    </dependencies>
 
    <profiles>

--- a/distribution/activemq/src/main/assembly/dep.xml
+++ b/distribution/activemq/src/main/assembly/dep.xml
@@ -64,6 +64,8 @@
             <include>org.eclipse.jetty.aggregate:jetty-all</include>
             <include>org.apache.geronimo.specs:</include>
             <include>org.apache.geronimo.specs:geronimo-servlet_3.0_spec</include>
+            <include>commons-beanutils:commons-beanutils</include>
+            <include>commons-logging:commons-logging</include>
          </includes>
          <!--excludes>
             <exclude>org.apache.activemq:activemq-website</exclude>

--- a/distribution/activemq/src/main/resources/config/clustered/activemq-configuration.xml
+++ b/distribution/activemq/src/main/resources/config/clustered/activemq-configuration.xml
@@ -37,34 +37,13 @@ under the License.
       <large-messages-directory>${data.dir:../data}/large-messages</large-messages-directory>
 
       <connectors>
-         <connector name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="host"  value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port"  value="${activemq.remoting.netty.port:5445}"/>
-         </connector>
-
-         <connector name="netty-throughput">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="host"  value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port"  value="${activemq.remoting.netty.batch.port:5455}"/>
-            <param key="batch-delay" value="50"/>
-         </connector>
+         <connector name="netty">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.port:5445}</connector>
+         <connector name="netty-throughput">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.batch.port:5455}?batchDelay=50</connector>
       </connectors>
 
       <acceptors>
-         <acceptor name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="host"  value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port"  value="${activemq.remoting.netty.port:5445}"/>
-         </acceptor>
-
-         <acceptor name="netty-throughput">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="host"  value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port"  value="${activemq.remoting.netty.batch.port:5455}"/>
-            <param key="batch-delay" value="50"/>
-            <param key="direct-deliver" value="false"/>
-         </acceptor>
+         <acceptor name="netty">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.port:5445}</acceptor>
+         <acceptor name="netty-throughput">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.batch.port:5455}?batchDelay=50;directDeliver=false</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/distribution/activemq/src/main/resources/config/non-clustered/activemq-configuration.xml
+++ b/distribution/activemq/src/main/resources/config/non-clustered/activemq-configuration.xml
@@ -35,34 +35,13 @@ under the License.
       <large-messages-directory>${data.dir:../data}/large-messages</large-messages-directory>
 
       <connectors>
-         <connector name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="host" value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port" value="${activemq.remoting.netty.port:5445}"/>
-         </connector>
-
-         <connector name="netty-throughput">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="host" value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port" value="${activemq.remoting.netty.batch.port:5455}"/>
-            <param key="batch-delay" value="50"/>
-         </connector>
+         <connector name="netty">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.port:5445}</connector>
+         <connector name="netty-throughput">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.batch.port:5455}?batchDelay=50</connector>
       </connectors>
 
       <acceptors>
-         <acceptor name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="host" value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port" value="${activemq.remoting.netty.port:5445}"/>
-         </acceptor>
-
-         <acceptor name="netty-throughput">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="host" value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port" value="${activemq.remoting.netty.batch.port:5455}"/>
-            <param key="batch-delay" value="50"/>
-            <param key="direct-deliver" value="false"/>
-         </acceptor>
+         <acceptor name="netty">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.port:5445}</acceptor>
+         <acceptor name="netty-throughput">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.batch.port:5455}?batchDelay=50;directDeliver=false</acceptor>
       </acceptors>
 
       <security-settings>

--- a/distribution/activemq/src/main/resources/config/replicated/activemq-configuration.xml
+++ b/distribution/activemq/src/main/resources/config/replicated/activemq-configuration.xml
@@ -42,34 +42,13 @@ under the License.
       <large-messages-directory>${data.dir:../data}/large-messages</large-messages-directory>
 
       <connectors>
-         <connector name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="host"  value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port"  value="${activemq.remoting.netty.port:5445}"/>
-         </connector>
-
-         <connector name="netty-throughput">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="host"  value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port"  value="${activemq.remoting.netty.batch.port:5455}"/>
-            <param key="batch-delay" value="50"/>
-         </connector>
+         <connector name="netty">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.port:5445}</connector>
+         <connector name="netty-throughput">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.batch.port:5455}?batchDelay=50</connector>
       </connectors>
 
       <acceptors>
-         <acceptor name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="host"  value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port"  value="${activemq.remoting.netty.port:5445}"/>
-         </acceptor>
-
-         <acceptor name="netty-throughput">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="host"  value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port"  value="${activemq.remoting.netty.batch.port:5455}"/>
-            <param key="batch-delay" value="50"/>
-            <param key="direct-deliver" value="false"/>
-         </acceptor>
+         <acceptor name="netty">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.port:5445}</acceptor>
+         <acceptor name="netty-throughput">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.batch.port:5455}?batchDelay=50;directDeliver=false</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/distribution/activemq/src/main/resources/config/shared-store/activemq-configuration.xml
+++ b/distribution/activemq/src/main/resources/config/shared-store/activemq-configuration.xml
@@ -42,34 +42,13 @@ under the License.
       <large-messages-directory>${data.dir:../data}/large-messages</large-messages-directory>
 
       <connectors>
-         <connector name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="host"  value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port"  value="${activemq.remoting.netty.port:5445}"/>
-         </connector>
-
-         <connector name="netty-throughput">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="host"  value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port"  value="${activemq.remoting.netty.batch.port:5455}"/>
-            <param key="batch-delay" value="50"/>
-         </connector>
+         <connector name="netty">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.port:5445}</connector>
+         <connector name="netty-throughput">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.batch.port:5455}?batchDelay=50</connector>
       </connectors>
 
       <acceptors>
-         <acceptor name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="host"  value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port"  value="${activemq.remoting.netty.port:5445}"/>
-         </acceptor>
-
-         <acceptor name="netty-throughput">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="host"  value="${activemq.remoting.netty.host:localhost}"/>
-            <param key="port"  value="${activemq.remoting.netty.batch.port:5455}"/>
-            <param key="batch-delay" value="50"/>
-            <param key="direct-deliver" value="false"/>
-         </acceptor>
+         <acceptor name="netty">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.port:5445}</acceptor>
+         <acceptor name="netty-throughput">tcp://${activemq.remoting.netty.host:localhost}:${activemq.remoting.netty.batch.port:5455}?batchDelay=50;directDeliver=false</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/core/perf/src/main/resources/server0/activemq-configuration.xml
+++ b/examples/core/perf/src/main/resources/server0/activemq-configuration.xml
@@ -31,12 +31,7 @@ under the License.
       <paging-directory>target/server0/data/messaging/paging</paging-directory>
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="tcp-no-delay" value="false"/>
-            <param key="tcp-send-buffer-size" value="1048576"/>
-            <param key="tcp-receive-buffer-size" value="1048576"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445?tcpNoDelay=false;tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576</acceptor>
       </acceptors>
 
       <security-enabled>false</security-enabled>

--- a/examples/core/vertx-connector/src/main/resources/server0/activemq-configuration.xml
+++ b/examples/core/vertx-connector/src/main/resources/server0/activemq-configuration.xml
@@ -36,16 +36,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/aerogear/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/aerogear/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- We need to create a core queue for the JMS queue explicitly because the connector will be deployed

--- a/examples/jms/applet/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/applet/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/application-layer-failover/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/application-layer-failover/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -29,10 +29,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/application-layer-failover/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/application-layer-failover/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -32,10 +32,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/bridge/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/bridge/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,18 +39,12 @@ under the License.
       <!-- Connectors -->
       <connectors>
          <!-- Connector to the other node -->
-         <connector name="remote-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="remote-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- We need to create a core queue for the JMS queue explicitly because the bridge will be deployed

--- a/examples/jms/bridge/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/bridge/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -38,10 +38,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/browser/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/browser/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/client-kickoff/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/client-kickoff/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,9 +40,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty">tcp://localhost:5445</acceptor>
       </acceptors>
    </core>
 

--- a/examples/jms/client-side-failoverlistener/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/client-side-failoverlistener/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -44,18 +44,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/client-side-failoverlistener/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/client-side-failoverlistener/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -45,18 +45,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/client-side-load-balancing/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/client-side-load-balancing/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -38,18 +38,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/client-side-load-balancing/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/client-side-load-balancing/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -36,18 +36,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/client-side-load-balancing/src/main/resources/activemq/server2/activemq-configuration.xml
+++ b/examples/jms/client-side-load-balancing/src/main/resources/activemq/server2/activemq-configuration.xml
@@ -34,18 +34,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5447</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5447</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-durable-subscription/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/clustered-durable-subscription/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,18 +40,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-durable-subscription/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/clustered-durable-subscription/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -40,18 +40,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-grouping/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/clustered-grouping/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -41,18 +41,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-grouping/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/clustered-grouping/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -40,18 +40,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-grouping/src/main/resources/activemq/server2/activemq-configuration.xml
+++ b/examples/jms/clustered-grouping/src/main/resources/activemq/server2/activemq-configuration.xml
@@ -40,18 +40,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5447</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5447</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-jgroups/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/clustered-jgroups/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -41,18 +41,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-jgroups/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/clustered-jgroups/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -40,18 +40,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-queue/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/clustered-queue/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,18 +40,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-queue/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/clustered-queue/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -40,18 +40,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-standalone/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/clustered-standalone/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,18 +40,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-standalone/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/clustered-standalone/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -40,18 +40,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-standalone/src/main/resources/activemq/server2/activemq-configuration.xml
+++ b/examples/jms/clustered-standalone/src/main/resources/activemq/server2/activemq-configuration.xml
@@ -40,18 +40,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5447</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5447</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-static-discovery/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/clustered-static-discovery/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -41,23 +41,14 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
          <!-- connector to the server1 -->
-         <connector name="server1-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="server1-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <cluster-connections>

--- a/examples/jms/clustered-static-discovery/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/clustered-static-discovery/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -40,23 +40,14 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
          <!-- connector to the server0 -->
-         <connector name="server0-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="server0-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-static-discovery/src/main/resources/activemq/server2/activemq-configuration.xml
+++ b/examples/jms/clustered-static-discovery/src/main/resources/activemq/server2/activemq-configuration.xml
@@ -37,23 +37,14 @@
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5447</connector>
          <!-- connector to the server0 -->
-         <connector name="server0-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="server0-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5447</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-static-discovery/src/main/resources/activemq/server3/activemq-configuration.xml
+++ b/examples/jms/clustered-static-discovery/src/main/resources/activemq/server3/activemq-configuration.xml
@@ -37,23 +37,14 @@
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5448"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5448</connector>
          <!-- connector to the server0 -->
-         <connector name="server0-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="server0-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5448"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5448</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-static-oneway/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/clustered-static-oneway/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -38,23 +38,14 @@
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
          <!-- connector to the server1 -->
-         <connector name="server1-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="server1-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <cluster-connections>

--- a/examples/jms/clustered-static-oneway/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/clustered-static-oneway/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -37,23 +37,14 @@
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
          <!-- connector to the server0 -->
-         <connector name="server2-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </connector>
+         <connector name="server2-connector">tcp://localhost:5447</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-static-oneway/src/main/resources/activemq/server2/activemq-configuration.xml
+++ b/examples/jms/clustered-static-oneway/src/main/resources/activemq/server2/activemq-configuration.xml
@@ -37,18 +37,12 @@
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5447</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5447</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-topic/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/clustered-topic/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -41,18 +41,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/clustered-topic/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/clustered-topic/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -40,18 +40,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/colocated-failover-scale-down/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/colocated-failover-scale-down/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,24 +40,14 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="invm-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory</factory-class>
-         </connector>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="invm-connector">vm://0</connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="invm-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>
-         </acceptor>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="invm-acceptor">vm://0</acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/colocated-failover-scale-down/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/colocated-failover-scale-down/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -40,24 +40,14 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="invm-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory</factory-class>
-         </connector>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="invm-connector">vm://0</connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="invm-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>
-         </acceptor>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="invm-acceptor">vm://0</acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/colocated-failover/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/colocated-failover/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,18 +40,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/colocated-failover/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/colocated-failover/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -40,18 +40,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/consumer-rate-limit/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/consumer-rate-limit/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/dead-letter/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/dead-letter/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -42,9 +42,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/delayed-redelivery/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/delayed-redelivery/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -42,9 +42,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/divert/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/divert/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -55,19 +55,13 @@ under the License.
 
       <connectors>
          <!-- This connector corresponds to the New York server -->
-         <connector name="newyork-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="newyork-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
 
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Divert configuration -->

--- a/examples/jms/divert/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/divert/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -43,10 +43,7 @@ under the License.
       <!-- Acceptors -->
 
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/durable-subscription/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/durable-subscription/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,10 +40,7 @@ under the License.
       <!-- Acceptors -->
 
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/embedded-simple/src/main/resources/activemq-configuration.xml
+++ b/examples/jms/embedded-simple/src/main/resources/activemq-configuration.xml
@@ -32,9 +32,7 @@ under the License.
       <persistence-enabled>false</persistence-enabled>
 
       <acceptors>
-         <acceptor name="in-vm">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="in-vm">vm://0</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/expiry/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/expiry/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -42,9 +42,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/ha-policy-autobackup/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/ha-policy-autobackup/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,29 +39,16 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="invm-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory</factory-class>
-         </connector>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="invm-connector">vm://0</connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
          <!-- connector to the server1 -->
-         <connector name="server1-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="server1-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="invm-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>
-         </acceptor>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="invm-acceptor">vm://0</acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- HA configuration -->

--- a/examples/jms/ha-policy-autobackup/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/ha-policy-autobackup/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -39,29 +39,16 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="invm-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory</factory-class>
-         </connector>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="invm-connector">vm://0</connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
          <!-- connector to the server0 -->
-         <connector name="server0-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="server0-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="invm-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>
-         </acceptor>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="invm-acceptor">vm://0</acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- HA configuration -->

--- a/examples/jms/http-transport/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/http-transport/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,10 +40,7 @@ under the License.
       <!-- Acceptors -->
 
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="8080"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:8080</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/instantiate-connection-factory/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/instantiate-connection-factory/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,10 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/interceptor/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/interceptor/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -44,9 +44,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/jms-auto-closeable/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/jms-auto-closeable/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/jms-bridge/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/jms-bridge/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -37,9 +37,7 @@ under the License.
       <paging-directory>${build.directory}/server0/data/messaging/paging</paging-directory>
 
       <acceptors>
-         <acceptor name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <security-settings>

--- a/examples/jms/jms-bridge/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/jms-bridge/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -37,12 +37,7 @@ under the License.
       <paging-directory>${build.directory}/server1/data/messaging/paging</paging-directory>
 
       <acceptors>
-         <acceptor name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <!-- the server accepts connections on all the server addresses -->
-            <param key="host" value="localhost"/>
-            <param key="port" value="5455"/>
-         </acceptor>
+         <acceptor name="netty">tcp://localhost:5455</acceptor>
       </acceptors>
 
       <security-settings>

--- a/examples/jms/jms-completion-listener/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/jms-completion-listener/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/jms-context/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/jms-context/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/jms-shared-consumer/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/jms-shared-consumer/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/jmx/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/jmx/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -43,9 +43,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/large-message/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/large-message/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/last-value-queue/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/last-value-queue/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/management-notifications/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/management-notifications/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -45,9 +45,7 @@ under the License.
 
       <!-- Netty standard TCP acceptor -->
       <acceptors>
-         <acceptor name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!--  Other configs -->

--- a/examples/jms/management/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/management/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -42,9 +42,7 @@ under the License.
 
       <!-- Netty standard TCP acceptor -->
       <acceptors>
-         <acceptor name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <security-settings>

--- a/examples/jms/message-counters/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/message-counters/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -48,9 +48,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/message-group/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/message-group/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/message-group2/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/message-group2/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/message-priority/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/message-priority/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/multiple-failover-failback/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/multiple-failover-failback/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -45,18 +45,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/multiple-failover-failback/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/multiple-failover-failback/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -45,18 +45,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/multiple-failover-failback/src/main/resources/activemq/server2/activemq-configuration.xml
+++ b/examples/jms/multiple-failover-failback/src/main/resources/activemq/server2/activemq-configuration.xml
@@ -44,18 +44,12 @@ under the License.
       </ha-policy>
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5447</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5447</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/multiple-failover/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/multiple-failover/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -45,18 +45,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/multiple-failover/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/multiple-failover/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -45,18 +45,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/multiple-failover/src/main/resources/activemq/server2/activemq-configuration.xml
+++ b/examples/jms/multiple-failover/src/main/resources/activemq/server2/activemq-configuration.xml
@@ -45,18 +45,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5447</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5447</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/no-consumer-buffering/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/no-consumer-buffering/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/non-transaction-failover/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/non-transaction-failover/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -38,18 +38,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/non-transaction-failover/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/non-transaction-failover/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -38,18 +38,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/openwire/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/openwire/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -38,21 +38,13 @@ under the License.
       <paging-directory>${build.directory}/server0/data/messaging/paging</paging-directory>
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
-         <acceptor name="openwire-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="protocols" value="OPENWIRE"/>
-            <param key="port" value="61616"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
+         <acceptor name="openwire-acceptor">tcp://localhost:61616?protocols=OPENWIRE</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/paging/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/paging/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -42,16 +42,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/perf/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/perf/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -33,12 +33,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="tcp-no-delay" value="false"/>
-            <param key="tcp-send-buffer-size" value="1048576"/>
-            <param key="tcp-receive-buffer-size" value="1048576"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445?tcpNoDelay=false;tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576</acceptor>
       </acceptors>
 
       <queues>

--- a/examples/jms/pre-acknowledge/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/pre-acknowledge/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/producer-rate-limit/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/producer-rate-limit/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/proton-cpp/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/proton-cpp/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,9 +40,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="proton-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="proton-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/proton-j/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/proton-j/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,10 +40,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="proton-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5672"/>
-         </acceptor>
+         <acceptor name="proton-acceptor">tcp://localhost:5672</acceptor>
       </acceptors>
 
       <queues>

--- a/examples/jms/proton-ruby/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/proton-ruby/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,11 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="proton-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="protocol" value="AMQP"/>
-            <param key="port" value="5672"/>
-         </acceptor>
+         <acceptor name="proton-acceptor">tcp://localhost:5672?protocols=AMQP;</acceptor>
       </acceptors>
 
       <queues>

--- a/examples/jms/queue-message-redistribution/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/queue-message-redistribution/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,18 +40,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/queue-message-redistribution/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/queue-message-redistribution/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -41,18 +41,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/queue-requestor/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/queue-requestor/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/queue-selector/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/queue-selector/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -38,9 +38,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/queue/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/queue/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/reattach-node/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/reattach-node/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,32 +40,20 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
 
          <!-- We just use this connector so we can send management operations while the other acceptor
          is stopped -->
-         <connector name="netty-connector2">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector2">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
 
          <!-- We just use this acceptor so we can send management operations while the other acceptor
          is stopped -->
-         <acceptor name="netty-acceptor2">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor2">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/replicated-failback-static/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/replicated-failback-static/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -51,22 +51,13 @@ under the License.
       </ha-policy>
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
-         <connector name="netty-backup-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
+         <connector name="netty-backup-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <cluster-connections>

--- a/examples/jms/replicated-failback-static/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/replicated-failback-static/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -53,22 +53,13 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-live-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-live-connector">tcp://localhost:5445</connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <cluster-connections>

--- a/examples/jms/replicated-failback/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/replicated-failback/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -51,18 +51,12 @@ under the License.
       </ha-policy>
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/replicated-failback/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/replicated-failback/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -51,22 +51,13 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-live-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-live-connector">tcp://localhost:5445</connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/replicated-multiple-failover/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/replicated-multiple-failover/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -45,18 +45,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/replicated-multiple-failover/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/replicated-multiple-failover/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -45,18 +45,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/replicated-multiple-failover/src/main/resources/activemq/server2/activemq-configuration.xml
+++ b/examples/jms/replicated-multiple-failover/src/main/resources/activemq/server2/activemq-configuration.xml
@@ -44,18 +44,12 @@ under the License.
       </ha-policy>
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5447</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5447</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/replicated-transaction-failover/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/replicated-transaction-failover/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -46,18 +46,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/replicated-transaction-failover/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/replicated-transaction-failover/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -46,18 +46,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/request-reply/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/request-reply/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/rest/dup-send/src/main/resources/activemq-configuration.xml
+++ b/examples/jms/rest/dup-send/src/main/resources/activemq-configuration.xml
@@ -33,19 +33,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="in-vm">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory</factory-class>
-         </connector>
+         <connector name="in-vm">vm://0</connector>
       </connectors>
 
       <acceptors>
-         <acceptor name="in-vm">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>
-         </acceptor>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="in-vm">vm://0</acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/rest/javascript-chat/src/main/resources/activemq-configuration.xml
+++ b/examples/jms/rest/javascript-chat/src/main/resources/activemq-configuration.xml
@@ -33,15 +33,11 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="in-vm">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory</factory-class>
-         </connector>
+         <connector name="in-vm">vm://0</connector>
       </connectors>
 
       <acceptors>
-         <acceptor name="in-vm">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="in-vm">vm://0</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/rest/jms-to-rest/src/main/resources/activemq-configuration.xml
+++ b/examples/jms/rest/jms-to-rest/src/main/resources/activemq-configuration.xml
@@ -33,19 +33,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="in-vm">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory</factory-class>
-         </connector>
+         <connector name="in-vm">vm://0</connector>
       </connectors>
 
       <acceptors>
-         <acceptor name="in-vm">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>
-         </acceptor>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="in-vm">vm://0</acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/rest/push/src/main/resources/activemq-configuration.xml
+++ b/examples/jms/rest/push/src/main/resources/activemq-configuration.xml
@@ -34,19 +34,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="in-vm">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory</factory-class>
-         </connector>
+         <connector name="in-vm">vm://0</connector>
       </connectors>
 
       <acceptors>
-         <acceptor name="in-vm">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>
-         </acceptor>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="in-vm">vm://0</acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/scale-down/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/scale-down/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,18 +40,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/scale-down/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/scale-down/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -40,22 +40,13 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
-         <connector name="server0-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
+         <connector name="server0-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/scheduled-message/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/scheduled-message/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/security/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/security/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -42,9 +42,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/send-acknowledgements/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/send-acknowledgements/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/spring-integration/src/main/resources/activemq-configuration.xml
+++ b/examples/jms/spring-integration/src/main/resources/activemq-configuration.xml
@@ -32,9 +32,7 @@ under the License.
       <persistence-enabled>false</persistence-enabled>
 
       <acceptors>
-         <acceptor name="in-vm">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="in-vm">vm://0</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/ssl-enabled/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/ssl-enabled/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,14 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-ssl-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="host" value="localhost"/>
-            <param key="port" value="5500"/>
-            <param key="ssl-enabled" value="true"/>
-            <param key="key-store-path" value="activemq/server0/activemq.example.keystore"/>
-            <param key="key-store-password" value="activemqexample"/>
-         </acceptor>
+         <acceptor name="netty-ssl-acceptor">tcp://localhost:5500?sslEnabled=true;keyStorePath=activemq/server0/activemq.example.keystore;keyStorePassword=activemqexample</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/ssl-enabled/src/main/resources/jndi.properties
+++ b/examples/jms/ssl-enabled/src/main/resources/jndi.properties
@@ -16,5 +16,5 @@
 # under the License.
 
 java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory
-connectionFactory.ConnectionFactory=tcp://localhost:5500?ssl-enabled=true&trust-store-path=activemq/server0/activemq.example.truststore&trust-store-password=activemqexample
+connectionFactory.ConnectionFactory=tcp://localhost:5500?sslEnabled=true&trustStorePath=activemq/server0/activemq.example.truststore&trustStorePassword=activemqexample
 queue.queue/exampleQueue=exampleQueue

--- a/examples/jms/static-selector-jms/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/static-selector-jms/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -41,9 +41,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/static-selector/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/static-selector/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <queues>

--- a/examples/jms/stomp-websockets/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/stomp-websockets/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,15 +40,10 @@ under the License.
       <!-- Acceptors -->
       <acceptors>
          <!-- a regular Netty acceptor used by the JMS client -->
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
          <!-- the stomp-acceptor is configured for the Stomp over Web Sockets and -->
          <!-- will listen on port 61614)              -->
-         <acceptor name="stomp-websocket">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="61614"/>
-         </acceptor>
+         <acceptor name="stomp-websocket">tcp://localhost:61614</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/stomp/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/stomp/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,16 +40,10 @@ under the License.
       <!-- Acceptors -->
       <acceptors>
          <!-- a regular Netty acceptor used by the JMS client -->
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
          <!-- the stomp-acceptor is configured for the Stomp protocol only and -->
          <!-- will listen on port 61613 (default Stomp port)              -->
-         <acceptor name="stomp-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="protocols" value="STOMP"/>
-            <param key="port" value="61613"/>
-         </acceptor>
+         <acceptor name="stomp-acceptor">tcp://localhost:61613?protocols=STOMP</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/stomp1.1/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/stomp1.1/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,16 +40,10 @@ under the License.
       <!-- Acceptors -->
       <acceptors>
          <!-- a regular Netty acceptor used by the JMS client -->
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
          <!-- the stomp-acceptor is configured for the Stomp protocol only and -->
          <!-- will listen on port 61613 (default Stomp port)              -->
-         <acceptor name="stomp-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="protocols" value="STOMP"/>
-            <param key="port" value="61613"/>
-         </acceptor>
+         <acceptor name="stomp-acceptor">tcp://localhost:61613?protocols=STOMP</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/stomp1.2/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/stomp1.2/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,16 +40,10 @@ under the License.
       <!-- Acceptors -->
       <acceptors>
          <!-- a regular Netty acceptor used by the JMS client -->
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
          <!-- the stomp-acceptor is configured for the Stomp protocol only and -->
          <!-- will listen on port 61613 (default Stomp port)              -->
-         <acceptor name="stomp-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="protocols" value="STOMP"/>
-            <param key="port" value="61613"/>
-         </acceptor>
+         <acceptor name="stomp-acceptor">tcp://localhost:61613?protocols=STOMP</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/stop-server-failover/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/stop-server-failover/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -45,18 +45,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/stop-server-failover/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/stop-server-failover/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -45,18 +45,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/symmetric-cluster/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/symmetric-cluster/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -43,19 +43,13 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
 
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/symmetric-cluster/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/symmetric-cluster/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -42,18 +42,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/symmetric-cluster/src/main/resources/activemq/server2/activemq-configuration.xml
+++ b/examples/jms/symmetric-cluster/src/main/resources/activemq/server2/activemq-configuration.xml
@@ -42,18 +42,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5447</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5447"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5447</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/symmetric-cluster/src/main/resources/activemq/server3/activemq-configuration.xml
+++ b/examples/jms/symmetric-cluster/src/main/resources/activemq/server3/activemq-configuration.xml
@@ -42,18 +42,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5448"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5448</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5448"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5448</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/symmetric-cluster/src/main/resources/activemq/server4/activemq-configuration.xml
+++ b/examples/jms/symmetric-cluster/src/main/resources/activemq/server4/activemq-configuration.xml
@@ -41,18 +41,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5449"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5449</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5449"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5449</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/symmetric-cluster/src/main/resources/activemq/server5/activemq-configuration.xml
+++ b/examples/jms/symmetric-cluster/src/main/resources/activemq/server5/activemq-configuration.xml
@@ -41,18 +41,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5450"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5450</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5450"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5450</acceptor>
       </acceptors>
 
       <!-- Clustering configuration -->

--- a/examples/jms/temp-queue/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/temp-queue/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -40,16 +40,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/topic-hierarchies/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/topic-hierarchies/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -50,9 +50,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/topic-selector-example1/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/topic-selector-example1/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/topic-selector-example2/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/topic-selector-example2/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/topic/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/topic/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/transaction-failover/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/transaction-failover/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -46,18 +46,12 @@ under the License.
       <!-- Connectors -->
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5445"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/transaction-failover/src/main/resources/activemq/server1/activemq-configuration.xml
+++ b/examples/jms/transaction-failover/src/main/resources/activemq/server1/activemq-configuration.xml
@@ -45,18 +45,12 @@ under the License.
 
       <!-- Connectors -->
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5446</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="port" value="5446"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5446</acceptor>
       </acceptors>
 
       <broadcast-groups>

--- a/examples/jms/transactional/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/transactional/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/xa-heuristic/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/xa-heuristic/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/xa-heuristic/src/main/resources/jndi.properties
+++ b/examples/jms/xa-heuristic/src/main/resources/jndi.properties
@@ -17,4 +17,5 @@
 
 java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory
 connectionFactory.ConnectionFactory=tcp://localhost:5445
+connectionFactory.XAConnectionFactory=tcp://localhost:5445?type=XA_CF
 queue.queue/exampleQueue=exampleQueue

--- a/examples/jms/xa-receive/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/xa-receive/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/xa-receive/src/main/resources/jndi.properties
+++ b/examples/jms/xa-receive/src/main/resources/jndi.properties
@@ -17,4 +17,5 @@
 
 java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory
 connectionFactory.ConnectionFactory=tcp://localhost:5445
+connectionFactory.XAConnectionFactory=tcp://localhost:5445?type=XA_CF
 queue.queue/exampleQueue=exampleQueue

--- a/examples/jms/xa-send/src/main/resources/activemq/server0/activemq-configuration.xml
+++ b/examples/jms/xa-send/src/main/resources/activemq/server0/activemq-configuration.xml
@@ -39,9 +39,7 @@ under the License.
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <!-- Other config -->

--- a/examples/jms/xa-send/src/main/resources/jndi.properties
+++ b/examples/jms/xa-send/src/main/resources/jndi.properties
@@ -17,4 +17,5 @@
 
 java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory
 connectionFactory.ConnectionFactory=tcp://localhost:5445
+connectionFactory.XAConnectionFactory=tcp://localhost:5445?type=XA_CF
 queue.queue/exampleQueue=exampleQueue

--- a/examples/soak/normal/server0/activemq-configuration.xml
+++ b/examples/soak/normal/server0/activemq-configuration.xml
@@ -26,24 +26,12 @@ under the License.
    </jms>
    <core xmlns="urn:activemq:core">
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-            <param key="tcp-no-delay" value="false"/>
-            <param key="tcp-send-buffer-size" value="1048576"/>
-            <param key="tcp-receive-buffer-size" value="1048576"/>
-            <param key="host" value="localhost"/>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445?tcpNoDelay=false;tcpSendBufferSize=1048576?tcpReceiveBufferSize=1048576</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-            <param key="tcp-no-delay" value="false"/>
-            <param key="tcp-send-buffer-size" value="1048576"/>
-            <param key="tcp-receive-buffer-size" value="1048576"/>
-            <param key="host" value="localhost"/>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445?tcpNoDelay=false;tcpSendBufferSize=1048576?tcpReceiveBufferSize=1048576 </acceptor>
       </acceptors>
 
       <security-enabled>false</security-enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -429,6 +429,15 @@
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
             <version>1.9.2</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+
+         <!-- needed by commons-beanutils-->
+         <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.2</version>
+            <!-- License: Apache 2.0 -->
          </dependency>
       </dependencies>
    </dependencyManagement>

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/stomp/StompTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/stomp/StompTestBase.java
@@ -107,7 +107,7 @@ public abstract class StompTestBase extends UnitTestCase
    // -------------------------------------------------------------------------
    @Override
    @Before
-   public void setUp() throws Exception
+   public void  setUp() throws Exception
    {
       super.setUp();
       priorityQueue = new ArrayBlockingQueue(1000);

--- a/tests/integration-tests/src/test/resources/colocated-server-start-stop-config1.xml
+++ b/tests/integration-tests/src/test/resources/colocated-server-start-stop-config1.xml
@@ -19,9 +19,7 @@
             xsi:schemaLocation="urn:activemq /schema/activemq-configuration.xsd">
 
    <connectors>
-      <connector name="netty-connector">
-         <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-      </connector>
+      <connector name="netty-connector">tcp://localhost:5445</connector>
    </connectors>
 
    <paging-directory>/tmp/activemq-unit-test/live1/paging</paging-directory>
@@ -30,9 +28,7 @@
    <large-messages-directory>/tmp/activemq-unit-test/live1/largemessages</large-messages-directory>
    
    <acceptors>
-      <acceptor name="netty-acceptor">
-         <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-      </acceptor>
+      <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
    </acceptors>
 
     <broadcast-groups>

--- a/tests/integration-tests/src/test/resources/colocated-server-start-stop-config2.xml
+++ b/tests/integration-tests/src/test/resources/colocated-server-start-stop-config2.xml
@@ -19,10 +19,7 @@
             xsi:schemaLocation="urn:activemq schema/activemq-configuration.xsd">
 
    <connectors>
-      <connector name="netty-connector">
-         <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-         <param key="port" value="5645"/>
-      </connector>
+      <connector name="netty-connector">tcp://localhost:5645</connector>
    </connectors>
 
    <paging-directory>/tmp/activemq-unit-test/live2/paging</paging-directory>
@@ -31,10 +28,7 @@
    <large-messages-directory>/tmp/activemq-unit-test/live2/largemessages</large-messages-directory>
    
    <acceptors>
-      <acceptor name="netty-acceptor">
-         <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         <param key="port" value="5645"/>
-      </acceptor>
+      <acceptor name="netty-acceptor">tcp://localhost:5645</acceptor>
    </acceptors>
 
     <broadcast-groups>

--- a/tests/integration-tests/src/test/resources/server-start-stop-config1.xml
+++ b/tests/integration-tests/src/test/resources/server-start-stop-config1.xml
@@ -23,17 +23,13 @@
    <core xmlns="urn:activemq:core">
 
       <connectors>
-         <connector name="netty-connector">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-         </connector>
+         <connector name="netty-connector">tcp://localhost:5445</connector>
       </connectors>
 
       <journal-directory>/tmp/activemq-unit-test/start-stop-data</journal-directory>
 
       <acceptors>
-         <acceptor name="netty-acceptor">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
+         <acceptor name="netty-acceptor">tcp://localhost:5445</acceptor>
       </acceptors>
 
       <security-enabled>false</security-enabled>

--- a/tests/integration-tests/src/test/resources/spring-activemq-config.xml
+++ b/tests/integration-tests/src/test/resources/spring-activemq-config.xml
@@ -29,15 +29,11 @@
        <!-- Connectors -->
 
        <connectors>
-           <connector name="in-vm">
-               <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory</factory-class>
-           </connector>
+           <connector name="in-vm">vm://0</connector>
        </connectors>
 
        <acceptors>
-           <acceptor name="in-vm">
-               <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>
-           </acceptor>
+           <acceptor name="in-vm">vm://0</acceptor>
        </acceptors>
 
        <!-- Other config -->

--- a/tests/jms-tests/src/test/resources/activemq-configuration.xml
+++ b/tests/jms-tests/src/test/resources/activemq-configuration.xml
@@ -24,30 +24,16 @@
 
       <!-- Connectors -->
       <connectors>
-
-         <connector name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
-         </connector>
-
-
-         <connector name="in-vm">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMConnectorFactory</factory-class>
-         </connector>
+         <connector name="netty">tcp://localhost:5445</connector>
+         <connector name="in-vm">vm://0</connector>
       </connectors>
 
       <!-- Acceptors -->
       <acceptors>
          <!-- In VM acceptor -->
-         <acceptor name="in-vm">
-            <factory-class>org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>
-            <param key="server-id" value="0"/>
-         </acceptor>
-
+         <acceptor name="in-vm">vm://0</acceptor>
          <!-- Netty TCP Acceptor -->
-         <acceptor name="netty">
-            <factory-class>org.apache.activemq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
-         </acceptor>
-
+         <acceptor name="netty">tcp://localhost:5445</acceptor>
       </acceptors>
 
      <journal-min-files>2</journal-min-files>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ACTIVEMQ6-80

The configuration of acceptors and connectors now takes a uri rather than params.

Note that the documentation still needs updating, I will do this separately to avoid holding anyone up.