### PR TITLE
Doclink

### DIFF
--- a/activemq-commons/src/main/java/org/apache/activemq/api/core/ActiveMQBuffer.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/api/core/ActiveMQBuffer.java
@@ -40,11 +40,13 @@ public interface ActiveMQBuffer
 
    /**
     * Returns the number of bytes this buffer can contain.
+    *
+    * @return the number of bytes this buffer can contain.
     */
    int capacity();
 
    /**
-    * Returns the {@code readerIndex} of this buffer.
+    * @return the {@code readerIndex} of this buffer.
     */
    int readerIndex();
 
@@ -55,17 +57,19 @@ public interface ActiveMQBuffer
     *         if the specified {@code readerIndex} is
     *            less than {@code 0} or
     *            greater than {@code this.writerIndex}
+    * @param readerIndex The reader's index The reader infex
     */
    void readerIndex(int readerIndex);
 
    /**
-    * Returns the {@code writerIndex} of this buffer.
+    * @return the {@code writerIndex} of this buffer.
     */
    int writerIndex();
 
    /**
     * Sets the {@code writerIndex} of this buffer.
     *
+    * @param writerIndex The writer's index
     * @throws IndexOutOfBoundsException
     *         if the specified {@code writerIndex} is
     *            less than {@code this.readerIndex} or
@@ -118,6 +122,8 @@ public interface ActiveMQBuffer
     * buf.setIndex(2, 4);
     * </pre>
     *
+    * @param readerIndex The reader's index
+    * @param writerIndex The writer's index
     * @throws IndexOutOfBoundsException
     *         if the specified {@code readerIndex} is less than 0,
     *         if the specified {@code writerIndex} is less than the specified
@@ -127,28 +133,22 @@ public interface ActiveMQBuffer
    void setIndex(int readerIndex, int writerIndex);
 
    /**
-    * Returns the number of readable bytes which is equal to
-    * {@code (this.writerIndex - this.readerIndex)}.
+    * @return the number of readable bytes which is equal to {@code (this.writerIndex - this.readerIndex)}.
     */
    int readableBytes();
 
    /**
-    * Returns the number of writable bytes which is equal to
-    * {@code (this.capacity - this.writerIndex)}.
+    * @return the number of writable bytes which is equal to {@code (this.capacity - this.writerIndex)}.
     */
    int writableBytes();
 
    /**
-    * Returns {@code true}
-    * if and only if {@code (this.writerIndex - this.readerIndex)} is greater
-    * than {@code 0}.
+    * @return {@code true} if and only if {@code (this.writerIndex - this.readerIndex)} is greater than {@code 0}.
     */
    boolean readable();
 
    /**
-    * Returns {@code true}
-    * if and only if {@code (this.capacity - this.writerIndex)} is greater
-    * than {@code 0}.
+    * @return {@code true}if and only if {@code (this.capacity - this.writerIndex)} is greater than {@code 0}.
     */
    boolean writable();
 
@@ -214,6 +214,8 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
     *
+    * @param index Index into the buffer
+    * @return The byte at the specified index
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 1} is greater than {@code this.capacity}
@@ -225,6 +227,8 @@ public interface ActiveMQBuffer
     * buffer.  This method does not modify {@code readerIndex} or
     * {@code writerIndex} of this buffer.
     *
+    * @param index Index into the buffer
+    * @return an unsigned byte at the specified absolute {@code index}
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 1} is greater than {@code this.capacity}
@@ -236,6 +240,8 @@ public interface ActiveMQBuffer
     * this buffer.  This method does not modify {@code readerIndex} or
     * {@code writerIndex} of this buffer.
     *
+    * @param index Index into the buffer
+    * @return a 16-bit short integer at the specified absolute {@code index}
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 2} is greater than {@code this.capacity}
@@ -247,6 +253,8 @@ public interface ActiveMQBuffer
     * {@code index} in this buffer.  This method does not modify
     * {@code readerIndex} or {@code writerIndex} of this buffer.
     *
+    * @param index Index into the buffer
+    * @return an unsigned 16-bit short integer
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 2} is greater than {@code this.capacity}
@@ -258,6 +266,8 @@ public interface ActiveMQBuffer
     * this buffer.  This method does not modify {@code readerIndex} or
     * {@code writerIndex} of this buffer.
     *
+    * @param index Index into the buffer
+    * @return a 32-bit integer at the specified absolute {@code index}
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 4} is greater than {@code this.capacity}
@@ -269,6 +279,8 @@ public interface ActiveMQBuffer
     * in this buffer.  This method does not modify {@code readerIndex} or
     * {@code writerIndex} of this buffer.
     *
+    * @param index The index into this buffer
+    * @return an unsigned 32-bit integer at the specified absolute {@code index}
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 4} is greater than {@code this.capacity}
@@ -280,6 +292,8 @@ public interface ActiveMQBuffer
     * this buffer.  This method does not modify {@code readerIndex} or
     * {@code writerIndex} of this buffer.
     *
+    * @param index Index into the buffer
+    * @return a 64-bit long integer at the specified absolute {@code index}
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 8} is greater than {@code this.capacity}
@@ -297,6 +311,8 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * the source buffer (i.e. {@code this}).
     *
+    * @param index Index into the buffer
+    * @param dst The destination buffer
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         if {@code index + dst.writableBytes} is greater than
@@ -315,7 +331,8 @@ public interface ActiveMQBuffer
     * the source buffer (i.e. {@code this}).
     *
     * @param length the number of bytes to transfer
-    *
+    * @param index Index into the buffer
+    * @param dst The destination buffer
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0},
     *         if {@code index + length} is greater than
@@ -330,8 +347,10 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex}
     * of both the source (i.e. {@code this}) and the destination.
     *
-    * @param dstIndex the first index of the destination
-    * @param length   the number of bytes to transfer
+    * @param dst The destination bufferIndex the first index of the destination
+    * @param length  The number of bytes to transfer
+    * @param index Index into the buffer
+    * @param dstIndex The index into the destination bufferThe destination buffer
     *
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0},
@@ -349,6 +368,8 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer
     *
+    * @param index Index into the buffer
+    * @param dst The destination buffer
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         if {@code index + dst.length} is greater than
@@ -362,8 +383,10 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex}
     * of this buffer.
     *
-    * @param dstIndex the first index of the destination
-    * @param length   the number of bytes to transfer
+    * @param dstIndex The first index of the destination
+    * @param length   The number of bytes to transfer
+    * @param index Index into the buffer
+    * @param dst The destination buffer
     *
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0},
@@ -382,6 +405,8 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer while the destination's {@code position} will be increased.
     *
+    * @param index Index into the buffer
+    * @param dst The destination buffer
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         if {@code index + dst.remaining()} is greater than
@@ -394,6 +419,8 @@ public interface ActiveMQBuffer
     * this buffer.  This method does not modify {@code readerIndex} or
     * {@code writerIndex} of this buffer.
     *
+    * @param index Index into the buffer
+    * @return a char at the specified absolute {@code index}
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 2} is greater than {@code this.capacity}
@@ -405,6 +432,8 @@ public interface ActiveMQBuffer
     * this buffer.  This method does not modify {@code readerIndex} or
     * {@code writerIndex} of this buffer.
     *
+    * @param index Index into the buffer
+    * @return a float at the specified absolute {@code index}
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 4} is greater than {@code this.capacity}
@@ -416,6 +445,8 @@ public interface ActiveMQBuffer
     * this buffer.  This method does not modify {@code readerIndex} or
     * {@code writerIndex} of this buffer.
     *
+    * @param index Index into the buffer
+    * @return a double at the specified absolute {@code index}
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 8} is greater than {@code this.capacity}
@@ -428,6 +459,8 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
     *
+    * @param index Index into the buffer
+    * @param value The specified byte
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 1} is greater than {@code this.capacity}
@@ -440,6 +473,8 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
     *
+    * @param index Index into the buffer
+    * @param value The specified 16-bit short integer
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 2} is greater than {@code this.capacity}
@@ -452,6 +487,8 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
     *
+    * @param index Index into the buffer
+    * @param value The specified 32-bit integer
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 4} is greater than {@code this.capacity}
@@ -464,6 +501,8 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
     *
+    * @param index Index into the buffer
+    * @param value The specified 64-bit long integer
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 8} is greater than {@code this.capacity}
@@ -481,6 +520,8 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * the source buffer (i.e. {@code this}).
     *
+    * @param index Index into the buffer
+    * @param src The source buffer
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         if {@code index + src.readableBytes} is greater than
@@ -499,6 +540,8 @@ public interface ActiveMQBuffer
     * the source buffer (i.e. {@code this}).
     *
     * @param length the number of bytes to transfer
+    * @param index Index into the buffer
+    * @param src The source buffer
     *
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0},
@@ -514,8 +557,10 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex}
     * of both the source (i.e. {@code this}) and the destination.
     *
-    * @param srcIndex the first index of the source
-    * @param length   the number of bytes to transfer
+    * @param src The source bufferIndex the first index of the source
+    * @param length  The number of bytes to transfer
+    * @param index Index into the buffer
+    * @param srcIndex The source buffer index
     *
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0},
@@ -533,6 +578,8 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
     *
+    * @param index Index into the buffer
+    * @param src The source buffer
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         if {@code index + src.length} is greater than
@@ -545,6 +592,11 @@ public interface ActiveMQBuffer
     * the specified absolute {@code index}.
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
+    *
+    * @param index Index into the buffer
+    * @param src The source buffer
+    * @param srcIndex The source buffer index
+    * @param length The number of bytes to transfer
     *
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0},
@@ -562,6 +614,8 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
     *
+    * @param index Index into the buffer
+    * @param src The source buffer
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         if {@code index + src.remaining()} is greater than
@@ -575,6 +629,8 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
     *
+    * @param index Index into the buffer
+    * @param value The specified char
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 2} is greater than {@code this.capacity}
@@ -587,6 +643,8 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
     *
+    * @param index Index into the buffer
+    * @param value The specified float
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 4} is greater than {@code this.capacity}
@@ -599,6 +657,8 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
     *
+    * @param index Index into the buffer
+    * @param value The specified double
     * @throws IndexOutOfBoundsException
     *         if the specified {@code index} is less than {@code 0} or
     *         {@code index + 8} is greater than {@code this.capacity}
@@ -609,6 +669,7 @@ public interface ActiveMQBuffer
     * Gets a byte at the current {@code readerIndex} and increases
     * the {@code readerIndex} by {@code 1} in this buffer.
     *
+    * @return a byte at the current {@code readerIndex}
     * @throws IndexOutOfBoundsException
     *         if {@code this.readableBytes} is less than {@code 1}
     */
@@ -618,6 +679,7 @@ public interface ActiveMQBuffer
     * Gets an unsigned byte at the current {@code readerIndex} and increases
     * the {@code readerIndex} by {@code 1} in this buffer.
     *
+    * @return an unsigned byte at the current {@code readerIndex}
     * @throws IndexOutOfBoundsException
     *         if {@code this.readableBytes} is less than {@code 1}
     */
@@ -627,6 +689,7 @@ public interface ActiveMQBuffer
     * Gets a 16-bit short integer at the current {@code readerIndex}
     * and increases the {@code readerIndex} by {@code 2} in this buffer.
     *
+    * @return a 16-bit short integer at the current {@code readerIndex}
     * @throws IndexOutOfBoundsException
     *         if {@code this.readableBytes} is less than {@code 2}
     */
@@ -636,6 +699,7 @@ public interface ActiveMQBuffer
     * Gets an unsigned 16-bit short integer at the current {@code readerIndex}
     * and increases the {@code readerIndex} by {@code 2} in this buffer.
     *
+    * @return an unsigned 16-bit short integer at the current {@code readerIndex}
     * @throws IndexOutOfBoundsException
     *         if {@code this.readableBytes} is less than {@code 2}
     */
@@ -645,6 +709,7 @@ public interface ActiveMQBuffer
     * Gets a 32-bit integer at the current {@code readerIndex}
     * and increases the {@code readerIndex} by {@code 4} in this buffer.
     *
+    * @return a 32-bit integer at the current {@code readerIndex}
     * @throws IndexOutOfBoundsException
     *         if {@code this.readableBytes} is less than {@code 4}
     */
@@ -654,6 +719,7 @@ public interface ActiveMQBuffer
     * Gets an unsigned 32-bit integer at the current {@code readerIndex}
     * and increases the {@code readerIndex} by {@code 4} in this buffer.
     *
+    * @return an unsigned 32-bit integer at the current {@code readerIndex}
     * @throws IndexOutOfBoundsException
     *         if {@code this.readableBytes} is less than {@code 4}
     */
@@ -663,6 +729,7 @@ public interface ActiveMQBuffer
     * Gets a 64-bit integer at the current {@code readerIndex}
     * and increases the {@code readerIndex} by {@code 8} in this buffer.
     *
+    * @return a 64-bit integer at the current {@code readerIndex}
     * @throws IndexOutOfBoundsException
     *         if {@code this.readableBytes} is less than {@code 8}
     */
@@ -672,6 +739,7 @@ public interface ActiveMQBuffer
     * Gets a char at the current {@code readerIndex}
     * and increases the {@code readerIndex} by {@code 2} in this buffer.
     *
+    * @return a char at the current {@code readerIndex}
     * @throws IndexOutOfBoundsException
     *         if {@code this.readableBytes} is less than {@code 2}
     */
@@ -681,6 +749,7 @@ public interface ActiveMQBuffer
     * Gets a float at the current {@code readerIndex}
     * and increases the {@code readerIndex} by {@code 4} in this buffer.
     *
+    * @return a float at the current {@code readerIndex}
     * @throws IndexOutOfBoundsException
     *         if {@code this.readableBytes} is less than {@code 4}
     */
@@ -690,6 +759,7 @@ public interface ActiveMQBuffer
     * Gets a double at the current {@code readerIndex}
     * and increases the {@code readerIndex} by {@code 8} in this buffer.
     *
+    * @return a double at the current {@code readerIndex}
     * @throws IndexOutOfBoundsException
     *         if {@code this.readableBytes} is less than {@code 8}
     */
@@ -699,6 +769,7 @@ public interface ActiveMQBuffer
     * Gets a boolean at the current {@code readerIndex}
     * and increases the {@code readerIndex} by {@code 1} in this buffer.
     *
+    * @return a boolean at the current {@code readerIndex}
     * @throws IndexOutOfBoundsException
     *         if {@code this.readableBytes} is less than {@code 1}
     */
@@ -706,26 +777,36 @@ public interface ActiveMQBuffer
 
    /**
     * Gets a SimpleString (potentially {@code null}) at the current {@code readerIndex}
+    *
+    * @return a SimpleString (potentially {@code null}) at the current {@code readerIndex}
     */
    SimpleString readNullableSimpleString();
 
    /**
     * Gets a String (potentially {@code null}) at the current {@code readerIndex}
+    *
+    * @return a String (potentially {@code null}) at the current {@code readerIndex}
     */
    String readNullableString();
 
    /**
     * Gets a non-null SimpleString at the current {@code readerIndex}
+    *
+    * @return a non-null SimpleString at the current {@code readerIndex}
     */
    SimpleString readSimpleString();
 
    /**
     * Gets a non-null String at the current {@code readerIndex}
+    *
+    * @return a non-null String at the current {@code readerIndex}
     */
    String readString();
 
    /**
     * Gets a UTF-8 String at the current {@code readerIndex}
+    *
+    * @return a UTF-8 String at the current {@code readerIndex}
     */
    String readUTF();
 
@@ -737,7 +818,7 @@ public interface ActiveMQBuffer
     * {@code 0} and {@code length} respectively.
     *
     * @param length the number of bytes to transfer
-    *
+
     * @return the newly created buffer which contains the transferred bytes
     *
     * @throws IndexOutOfBoundsException
@@ -769,6 +850,7 @@ public interface ActiveMQBuffer
     * the transferred bytes while {@link #readBytes(ActiveMQBuffer, int, int)}
     * does not.
     *
+    * @param dst The destination buffer
     * @throws IndexOutOfBoundsException
     *         if {@code dst.writableBytes} is greater than
     *            {@code this.readableBytes}
@@ -784,6 +866,8 @@ public interface ActiveMQBuffer
     * destination by the number of the transferred bytes (= {@code length})
     * while {@link #readBytes(ActiveMQBuffer, int, int)} does not.
     *
+    * @param dst The destination buffer
+    * @param length The number of bytes to transfer
     * @throws IndexOutOfBoundsException
     *         if {@code length} is greater than {@code this.readableBytes} or
     *         if {@code length} is greater than {@code dst.writableBytes}
@@ -795,8 +879,9 @@ public interface ActiveMQBuffer
     * the current {@code readerIndex} and increases the {@code readerIndex}
     * by the number of the transferred bytes (= {@code length}).
     *
-    * @param dstIndex the first index of the destination
+    * @param dstIndex The destination buffer index
     * @param length   the number of bytes to transfer
+    * @param dst The destination buffer
     *
     * @throws IndexOutOfBoundsException
     *         if the specified {@code dstIndex} is less than {@code 0},
@@ -811,6 +896,7 @@ public interface ActiveMQBuffer
     * the current {@code readerIndex} and increases the {@code readerIndex}
     * by the number of the transferred bytes (= {@code dst.length}).
     *
+    * @param dst The destination buffer
     * @throws IndexOutOfBoundsException
     *         if {@code dst.length} is greater than {@code this.readableBytes}
     */
@@ -821,8 +907,9 @@ public interface ActiveMQBuffer
     * the current {@code readerIndex} and increases the {@code readerIndex}
     * by the number of the transferred bytes (= {@code length}).
     *
-    * @param dstIndex the first index of the destination
+    * @param dstIndex The destination bufferIndex
     * @param length   the number of bytes to transfer
+    * @param dst The destination buffer
     *
     * @throws IndexOutOfBoundsException
     *         if the specified {@code dstIndex} is less than {@code 0},
@@ -837,6 +924,7 @@ public interface ActiveMQBuffer
     * reaches its limit, and increases the {@code readerIndex} by the
     * number of the transferred bytes.
     *
+    * @param dst The destination buffer
     * @throws IndexOutOfBoundsException
     *         if {@code dst.remaining()} is greater than
     *            {@code this.readableBytes}
@@ -847,6 +935,7 @@ public interface ActiveMQBuffer
     * Increases the current {@code readerIndex} by the specified
     * {@code length} in this buffer.
     *
+    * @param length The number of bytes to skip
     * @throws IndexOutOfBoundsException
     *         if {@code length} is greater than {@code this.readableBytes}
     */
@@ -856,6 +945,7 @@ public interface ActiveMQBuffer
     * Sets the specified byte at the current {@code writerIndex}
     * and increases the {@code writerIndex} by {@code 1} in this buffer.
     *
+    * @param value The specified byte
     * @throws IndexOutOfBoundsException
     *         if {@code this.writableBytes} is less than {@code 1}
     */
@@ -866,6 +956,7 @@ public interface ActiveMQBuffer
     * {@code writerIndex} and increases the {@code writerIndex} by {@code 2}
     * in this buffer.
     *
+    * @param value The specified 16-bit short integer
     * @throws IndexOutOfBoundsException
     *         if {@code this.writableBytes} is less than {@code 2}
     */
@@ -875,6 +966,7 @@ public interface ActiveMQBuffer
     * Sets the specified 32-bit integer at the current {@code writerIndex}
     * and increases the {@code writerIndex} by {@code 4} in this buffer.
     *
+    * @param value The specified 32-bit integer
     * @throws IndexOutOfBoundsException
     *         if {@code this.writableBytes} is less than {@code 4}
     */
@@ -885,6 +977,7 @@ public interface ActiveMQBuffer
     * {@code writerIndex} and increases the {@code writerIndex} by {@code 8}
     * in this buffer.
     *
+    * @param value The specified 64-bit long integer
     * @throws IndexOutOfBoundsException
     *         if {@code this.writableBytes} is less than {@code 8}
     */
@@ -894,6 +987,7 @@ public interface ActiveMQBuffer
     * Sets the specified char at the current {@code writerIndex}
     * and increases the {@code writerIndex} by {@code 2} in this buffer.
     *
+    * @param chr The specified char
     * @throws IndexOutOfBoundsException
     *         if {@code this.writableBytes} is less than {@code 2}
     */
@@ -903,6 +997,7 @@ public interface ActiveMQBuffer
     * Sets the specified float at the current {@code writerIndex}
     * and increases the {@code writerIndex} by {@code 4} in this buffer.
     *
+    * @param value The specified float
     * @throws IndexOutOfBoundsException
     *         if {@code this.writableBytes} is less than {@code 4}
     */
@@ -912,6 +1007,7 @@ public interface ActiveMQBuffer
     * Sets the specified double at the current {@code writerIndex}
     * and increases the {@code writerIndex} by {@code 8} in this buffer.
     *
+    * @param value The specified double
     * @throws IndexOutOfBoundsException
     *         if {@code this.writableBytes} is less than {@code 8}
     */
@@ -919,31 +1015,42 @@ public interface ActiveMQBuffer
 
    /**
     * Sets the specified boolean at the current {@code writerIndex}
+    * @param val The specified boolean
     */
    void writeBoolean(boolean val);
 
    /**
     * Sets the specified SimpleString (potentially {@code null}) at the current {@code writerIndex}
+    *
+    * @param val The specified SimpleString
     */
    void writeNullableSimpleString(SimpleString val);
 
    /**
     * Sets the specified String (potentially {@code null}) at the current {@code writerIndex}
+    *
+    * @param val The specified String
     */
    void writeNullableString(String val);
 
    /**
     * Sets the specified non-null SimpleString at the current {@code writerIndex}
+    *
+    * @param val The specified non-null SimpleString
     */
    void writeSimpleString(SimpleString val);
 
    /**
     * Sets the specified non-null String at the current {@code writerIndex}
+    *
+    * @param val The specified non-null String
     */
    void writeString(String val);
 
    /**
     * Sets the specified UTF-8 String at the current {@code writerIndex}
+    *
+    * @param utf The specified UTF-8 String
     */
 
    void writeUTF(String utf);
@@ -958,7 +1065,7 @@ public interface ActiveMQBuffer
     * {@link #writeBytes(ActiveMQBuffer, int, int)} does not.
     *
     * @param length the number of bytes to transfer
-    *
+    * @param src The source buffer
     * @throws IndexOutOfBoundsException
     *         if {@code length} is greater than {@code this.writableBytes} or
     *         if {@code length} is greater then {@code src.readableBytes}
@@ -972,6 +1079,7 @@ public interface ActiveMQBuffer
     *
     * @param srcIndex the first index of the source
     * @param length   the number of bytes to transfer
+    * @param src The source buffer
     *
     * @throws IndexOutOfBoundsException
     *         if the specified {@code srcIndex} is less than {@code 0},
@@ -986,6 +1094,7 @@ public interface ActiveMQBuffer
     * the current {@code writerIndex} and increases the {@code writerIndex}
     * by the number of the transferred bytes (= {@code src.length}).
     *
+    * @param src The source buffer
     * @throws IndexOutOfBoundsException
     *         if {@code src.length} is greater than {@code this.writableBytes}
     */
@@ -998,6 +1107,7 @@ public interface ActiveMQBuffer
     *
     * @param srcIndex the first index of the source
     * @param length   the number of bytes to transfer
+    * @param src The source buffer
     *
     * @throws IndexOutOfBoundsException
     *         if the specified {@code srcIndex} is less than {@code 0},
@@ -1013,6 +1123,7 @@ public interface ActiveMQBuffer
     * reaches its limit, and increases the {@code writerIndex} by the
     * number of the transferred bytes.
     *
+    * @param src The source buffer
     * @throws IndexOutOfBoundsException
     *         if {@code src.remaining()} is greater than
     *            {@code this.writableBytes}
@@ -1026,6 +1137,7 @@ public interface ActiveMQBuffer
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
     *
+    * @return a copy of this buffer's readable bytes.
     */
    ActiveMQBuffer copy();
 
@@ -1034,6 +1146,10 @@ public interface ActiveMQBuffer
     * the returned buffer or this buffer does not affect each other at all.
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
+    *
+    * @param index Index into the buffer
+    * @param length The number of bytes to copy
+    * @return a copy of this buffer's readable bytes.
     */
    ActiveMQBuffer copy(int index, int length);
 
@@ -1044,6 +1160,8 @@ public interface ActiveMQBuffer
     * identical to {@code buf.slice(buf.readerIndex(), buf.readableBytes())}.
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
+    *
+    * @return a slice of this buffer's readable bytes
     */
    ActiveMQBuffer slice();
 
@@ -1053,6 +1171,10 @@ public interface ActiveMQBuffer
     * they maintain separate indexes and marks.
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
+    *
+    * @param index Index into the buffer
+    * @param length The number of bytes
+    * @return a slice of this buffer's sub-region.
     */
    ActiveMQBuffer slice(int index, int length);
 
@@ -1063,6 +1185,8 @@ public interface ActiveMQBuffer
     * This method is identical to {@code buf.slice(0, buf.capacity())}.
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
+    *
+    * @return a buffer which shares the whole region of this buffer.
     */
    ActiveMQBuffer duplicate();
 
@@ -1073,6 +1197,8 @@ public interface ActiveMQBuffer
     * {@code buf.toByteBuffer(buf.readerIndex(), buf.readableBytes())}.
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
+    *
+    * @return A converted NIO ByteBuffer
     */
    ByteBuffer toByteBuffer();
 
@@ -1082,6 +1208,10 @@ public interface ActiveMQBuffer
     * they have separate indexes and marks.
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
+    *
+    * @param index Index into the buffer
+    * @param length The number of bytes
+    * @return A converted NIO Buffer
     */
    ByteBuffer toByteBuffer(int index, int length);
 }

--- a/activemq-commons/src/main/java/org/apache/activemq/api/core/ActiveMQInterceptorRejectedPacketException.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/api/core/ActiveMQInterceptorRejectedPacketException.java
@@ -20,7 +20,7 @@ import static org.apache.activemq.api.core.ActiveMQExceptionType.INTERCEPTOR_REJ
 
 /**
  * An outgoing interceptor returned false.
- * @see org.apache.activemq.api.core.client.ServerLocator#addOutgoingInterceptor(org.apache.activemq.api.core.Interceptor)
+ * See org.apache.activemq.api.core.client.ServerLocator#addOutgoingInterceptor(org.apache.activemq.api.core.Interceptor)
  * @author Justin Bertram
  */
 // XXX I doubt any reader will make much sense of this Javadoc's text.

--- a/activemq-commons/src/main/java/org/apache/activemq/api/core/ActiveMQPropertyConversionException.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/api/core/ActiveMQPropertyConversionException.java
@@ -20,7 +20,6 @@ package org.apache.activemq.api.core;
  * A PropertyConversionException is thrown by {@code org.apache.activemq.api.core.Message} methods when a
  * property can not be converted to the expected type.
  * @author <a href="mailto:jmesnil@redhat.com">Jeff Mesnil</a>
- * @see org.apache.activemq.api.core.Message
  */
 public final class ActiveMQPropertyConversionException extends RuntimeException
 {

--- a/activemq-commons/src/main/java/org/apache/activemq/api/core/SimpleString.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/api/core/SimpleString.java
@@ -52,6 +52,7 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
     * If {@code string} is {@code null}, the return value will be {@code null} too.
     *
     * @param string String used to instantiate a SimpleString.
+    * @return A new SimpleString
     */
    public static SimpleString toSimpleString(final String string)
    {
@@ -267,7 +268,8 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
     * Splits this SimpleString into an array of SimpleString using the char param as the delimiter.
     * i.e. "a.b" would return "a" and "b" if . was the delimiter
     *
-    * @param delim
+    * @param delim The delimiter to split this SimpleString on.
+    * @return An array of SimpleStrings
     */
    public SimpleString[] split(final char delim)
    {
@@ -419,10 +421,10 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
     * This method performs a similar function to {@link String#getChars(int, int, char[], int)}.
     * This is mainly used by the Parsers on Filters
     *
-    * @param srcBegin
-    * @param srcEnd
-    * @param dst
-    * @param dstPos
+    * @param srcBegin The srcBegin
+    * @param srcEnd The srcEnd
+    * @param dst The destination array
+    * @param dstPos The destination position
     */
    public void getChars(final int srcBegin, final int srcEnd, final char[] dst, final int dstPos)
    {

--- a/activemq-commons/src/main/java/org/apache/activemq/utils/Base64.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/utils/Base64.java
@@ -879,6 +879,8 @@ public class Base64
     * Encodes or decodes two files from the command line;
     * <strong>feel free to delete this method (in fact you probably should)
     * if you're embedding this code into a larger program.</strong>
+    *
+    * @param args Input args
     */
    public static final void main(final String[] args)
    {
@@ -1131,6 +1133,7 @@ public class Base64
     * Does not GZip-compress data.
     *
     * @param source The data to convert
+    * @return Base64 String
     * @since 1.4
     */
    public static String encodeBytes(final byte[] source)
@@ -1153,6 +1156,7 @@ public class Base64
     *
     * @param source  The data to convert
     * @param options Specified options
+    * @return Encoded String
     * @see Base64#GZIP
     * @see Base64#DONT_BREAK_LINES
     * @since 2.0
@@ -1169,6 +1173,7 @@ public class Base64
     * @param source The data to convert
     * @param off    Offset in array where conversion should begin
     * @param len    Length of data to convert
+    * @return Encoded String
     * @since 1.4
     */
    public static String encodeBytes(final byte[] source, final int off, final int len)
@@ -1193,6 +1198,7 @@ public class Base64
     * @param off     Offset in array where conversion should begin
     * @param len     Length of data to convert
     * @param options options alphabet type is pulled from this (standard, url-safe, ordered)
+    * @return Encoded String
     * @see Base64#GZIP
     * @see Base64#DONT_BREAK_LINES
     * @since 2.0
@@ -1395,6 +1401,7 @@ public class Base64
     * @param source The Base64 encoded data
     * @param off    The offset of where to begin decoding
     * @param len    The length of characters to decode
+    * @param options Specified options
     * @return decoded data
     * @since 1.3
     */
@@ -2230,6 +2237,7 @@ public class Base64
        * at a time.
        *
        * @param theByte the byte to write
+       * @throws java.io.IOException Throws IOException
        * @since 1.3
        */
       @Override
@@ -2291,6 +2299,7 @@ public class Base64
        * @param off      offset for array
        * @param len      max number of bytes to read into array
        * @since 1.3
+       * @throws java.io.IOException Throws IOException
        */
       @Override
       public void write(final byte[] theBytes, final int off, final int len) throws java.io.IOException
@@ -2312,6 +2321,7 @@ public class Base64
       /**
        * Method added by PHIL. [Thanks, PHIL. -Rob]
        * This pads the buffer without closing the stream.
+       * @throws java.io.IOException On IO Exception
        */
       public void flushBase64() throws java.io.IOException
       {
@@ -2333,7 +2343,9 @@ public class Base64
       /**
        * Flushes and closes (I think, in the superclass) the stream.
        *
+       * @throws java.io.IOException Throws IOException
        * @since 1.3
+       *
        */
       @Override
       public void close() throws java.io.IOException
@@ -2353,7 +2365,7 @@ public class Base64
        * Suspends encoding of the stream.
        * May be helpful if you need to embed a piece of
        * base640-encoded data in a stream.
-       *
+       * @throws java.io.IOException On IO Exception
        * @since 1.5.1
        */
       public void suspendEncoding() throws java.io.IOException

--- a/activemq-commons/src/main/java/org/apache/activemq/utils/ConcurrentSet.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/utils/ConcurrentSet.java
@@ -24,7 +24,7 @@ import java.util.Set;
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>
  *
- * @param <E>
+ * @param <E> The generic class
  */
 public interface ConcurrentSet<E> extends Set<E>
 {

--- a/activemq-commons/src/main/java/org/apache/activemq/utils/FactoryFinder.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/utils/FactoryFinder.java
@@ -26,10 +26,8 @@ public class FactoryFinder
 {
    /**
     * The strategy that the FactoryFinder uses to find load and instantiate Objects
-    * can be changed out by calling the
-    * {@link org.apache.activemq.utils.FactoryFinder#setObjectFactory(org.apache.activemq.utils.FactoryFinder.ObjectFactory)}
-    * method with a custom implementation of ObjectFactory.
-    * <p/>
+    * can be changed out by calling the setObjectFactory method with a custom implementation of ObjectFactory.
+    *
     * The default ObjectFactory is typically changed out when running in a specialized container
     * environment where service discovery needs to be done via the container system.  For example,
     * in an OSGi scenario.
@@ -38,7 +36,11 @@ public class FactoryFinder
    {
       /**
        * @param path the full service path
-       * @return
+       * @throws IllegalAccessException illegal access
+       * @throws InstantiationException on instantiation error
+       * @throws IOException On IO Error
+       * @throws ClassNotFoundException On class not found error
+       * @return Object
        */
       Object create(String path) throws IllegalAccessException, InstantiationException, IOException, ClassNotFoundException;
 
@@ -162,6 +164,10 @@ public class FactoryFinder
     * @param key is the key to add to the path to find a text file containing
     *            the factory name
     * @return a newly created instance
+    * @throws IllegalAccessException On illegal access
+    * @throws InstantiationException On can not instantiate exception
+    * @throws IOException On IOException
+    * @throws ClassNotFoundException When class not on class path
     */
    public Object newInstance(String key) throws IllegalAccessException, InstantiationException, IOException, ClassNotFoundException
    {

--- a/activemq-commons/src/main/java/org/apache/activemq/utils/TypedProperties.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/utils/TypedProperties.java
@@ -1152,11 +1152,11 @@ public final class TypedProperties
    }
 
    /**
-    * Helper for {@link MapMessage#setObjectProperty(String, Object)}
+    * Helper for MapMessage#setObjectProperty(String, Object)
     *
-    * @param key
-    * @param value
-    * @param properties
+    * @param key The SimpleString key
+    * @param value The Object value
+    * @param properties The typed properties
     */
    public static void setObjectProperty(final SimpleString key, final Object value, final TypedProperties properties)
    {

--- a/activemq-commons/src/main/java/org/apache/activemq/utils/UUID.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/utils/UUID.java
@@ -216,7 +216,7 @@ public final class UUID
    /**
     * Creates a 128bit number from the String representation of {@link UUID}.
     *
-    * @param uuid
+    * @param uuid The UUID
     * @return byte array that can be used to recreate a UUID instance from the given String
     * representation
     */

--- a/activemq-commons/src/main/java/org/apache/activemq/utils/UUIDGenerator.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/utils/UUIDGenerator.java
@@ -61,6 +61,8 @@ public final class UUIDGenerator
 
    /**
     * Method used for accessing the singleton generator instance.
+    *
+    * @return Instance of UUID Generator
     */
    public static UUIDGenerator getInstance()
    {
@@ -77,7 +79,9 @@ public final class UUIDGenerator
     * the UUIDs. This way the initialization cost is only taken once; access
     * need not be synchronized (or in cases where it has to, SecureRandom takes
     * care of it); it might even be good for getting really 'random' stuff to
-    * get shared access...
+    * get shared access..
+    *
+    * @return A Random number generator.
     */
    public Random getRandomNumberGenerator()
    {
@@ -135,6 +139,8 @@ public final class UUIDGenerator
    /**
     * If running java 6 or above, returns {@link NetworkInterface#getHardwareAddress()}, else return {@code null}.
     * The first hardware address is returned when iterating all the NetworkInterfaces
+    *
+    * @return A byte array containing teh hardware address.
     */
    public static byte[] getHardwareAddress()
    {

--- a/activemq-commons/src/main/java/org/apache/activemq/utils/uri/URISchema.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/utils/uri/URISchema.java
@@ -102,10 +102,10 @@ public abstract class URISchema<T>
    /**
     * It will create a new Object for the URI selected schema.
     * the propertyOverrides is used to replace whatever was defined on the URL string
-    * @param uri
-    * @param propertyOverrides
-    * @return
-    * @throws Exception
+    * @param uri The URI
+    * @param propertyOverrides  used to replace whatever was defined on the URL string
+    * @return new Object
+    * @throws Exception On error
     */
    public T newObject(URI uri, Map<String, String> propertyOverrides) throws Exception
    {

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
       <skipRestTests>true</skipRestTests>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-      <additionalparam>-Xdoclint:none</additionalparam>
 
      <!--
 
@@ -618,6 +617,15 @@
             <skipTests>true</skipTests>
          </properties>
       </profile>
+      <profile>
+         <id>jdk8</id>
+         <activation>
+            <jdk>1.7</jdk>
+         </activation>
+         <properties>
+            <javadoc.opts>-Xdoclint:none</javadoc.opts>
+         </properties>
+      </profile>
    </profiles>
 
    <build>
@@ -787,6 +795,9 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+               <additionalparam>${javadoc.opts}</additionalparam>
+            </configuration>
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -973,6 +984,7 @@
                <aggregate>true</aggregate>
                <excludePackageNames>com.restfully.*:org.jboss.resteasy.examples.*:org.jboss.resteasy.tests.*
                </excludePackageNames>
+               <additionalparam>${javadoc.opts}</additionalparam>
             </configuration>
          </plugin>
          <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -620,7 +620,7 @@
       <profile>
          <id>jdk8</id>
          <activation>
-            <jdk>1.7</jdk>
+            <jdk>1.8</jdk>
          </activation>
          <properties>
             <javadoc.opts>-Xdoclint:none</javadoc.opts>


### PR DESCRIPTION
The addition parameter turning off doclint was causing problems when building with JDK7.  This is not only set on JDK8.

Additional path to make activemq-commons module is doclint compliant.