### PR TITLE
ACTIVEMQ6-82 activemq.conf file for runtime opts

### DIFF
--- a/distribution/activemq/src/main/resources/bin/activemq
+++ b/distribution/activemq/src/main/resources/bin/activemq
@@ -95,8 +95,8 @@ for i in `ls $ACTIVEMQ_HOME/lib/*.jar`; do
 	CLASSPATH=$i:$CLASSPATH
 done
 
+source $ACTIVEMQ_HOME/bin/activemq.conf
 
-JAVA_ARGS="-XX:+UseParallelGC -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Xms512M -Xmx1024M -Dactivemq.home=$ACTIVEMQ_HOME -Ddata.dir=$ACTIVEMQ_HOME/data -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dlogging.configuration=file:$ACTIVEMQ_HOME/config/logging.properties -Djava.library.path=$ACTIVEMQ_HOME/bin/lib/linux-i686:$ACTIVEMQ_HOME/bin/lib/linux-x86_64"
-#JAVA_ARGS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
+JAVA_ARGS="$JAVA_ARGS $ACTIVEMQ_CLUSTER_PROPS -Dactivemq.home=$ACTIVEMQ_HOME -Djava.library.path=$ACTIVEMQ_HOME/bin/lib/linux-i686:$ACTIVEMQ_HOME/bin/lib/linux-x86_64 -Ddata.dir=$ACTIVEMQ_DATA_DIR -Djava.util.logging.manager=$ACTIVEMQ_LOG_MANAGER -Dlogging.configuration=$ACTIVEMQ_LOGGING_CONF $DEBUG_ARGS"
 
 exec "$JAVACMD" $JAVA_ARGS -classpath $CLASSPATH org.apache.activemq.cli.ActiveMQ $@

--- a/distribution/activemq/src/main/resources/bin/activemq.conf
+++ b/distribution/activemq/src/main/resources/bin/activemq.conf
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Path to logging configuration file
+ACTIVEMQ_LOGGING_CONF="file:$ACTIVEMQ_HOME/config/logging.properties"
+
+# Path to data directory
+ACTIVEMQ_DATA_DIR=$ACTIVEMQ_HOME/data
+
+# Log manager class
+ACTIVEMQ_LOG_MANAGER=org.jboss.logmanager.LogManager
+
+# Cluster Properties: Used to pass arguments to ActiveMQ which can be referenced in activemq-configuration.xml
+#ACTIVEMQ_CLUSTER_PROPS="-Dactivemq.remoting.netty.port=5447"
+
+# Java Opts
+JAVA_ARGS="-XX:+UseParallelGC -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Xms512M -Xmx1024M"
+
+# Debug args: Uncomment to enable debug
+#DEBUG_ARGS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"


### PR DESCRIPTION
Linux support only.  Allows users to define java args and a number of other
runtime configuration parameters outside of the run scripts.  This will
be followed up with support for cmd.