### PR TITLE
ACTIVEMQ6-84 - JMSServerManagerImpl.activated() doesn't get called when ...

### DIFF
--- a/activemq-bootstrap/pom.xml
+++ b/activemq-bootstrap/pom.xml
@@ -60,6 +60,29 @@
          <groupId>io.airlift</groupId>
          <artifactId>airline</artifactId>
       </dependency>
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>activemq-amqp-protocol</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>activemq-stomp-protocol</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>activemq-openwire-protocol</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/activemq-bootstrap/src/main/java/org/apache/activemq/integration/FileBroker.java
+++ b/activemq-bootstrap/src/main/java/org/apache/activemq/integration/FileBroker.java
@@ -25,6 +25,7 @@ import org.apache.activemq.jms.server.config.impl.FileJMSConfiguration;
 import org.apache.activemq.spi.core.security.ActiveMQSecurityManager;
 
 import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
 import java.util.Map;
 
 /**
@@ -64,8 +65,9 @@ public class FileBroker implements Broker
 
       components = fileDeploymentManager.buildService(securityManager, ManagementFactory.getPlatformMBeanServer());
 
+      ArrayList<ActiveMQComponent> componentsByStartOrder = getComponentsByStartOrder(components);
       ActiveMQBootstrapLogger.LOGGER.serverStarting();
-      for (ActiveMQComponent component : components.values())
+      for (ActiveMQComponent component : componentsByStartOrder)
       {
          component.start();
       }
@@ -93,6 +95,27 @@ public class FileBroker implements Broker
    @Override
    public boolean isStarted()
    {
-      return false;
+      return started;
+   }
+
+   public Map<String, ActiveMQComponent> getComponents()
+   {
+      return components;
+   }
+
+   /*
+   * this makes sure the components are started in the correct order. Its simple at the mo as e only have core and jms but
+   * will need impproving if we get more.
+   * */
+   public ArrayList<ActiveMQComponent> getComponentsByStartOrder(Map<String, ActiveMQComponent> components)
+   {
+      ArrayList<ActiveMQComponent> activeMQComponents = new ArrayList<ActiveMQComponent>();
+      ActiveMQComponent jmsComponent = components.get("jms");
+      if (jmsComponent != null)
+      {
+         activeMQComponents.add(jmsComponent);
+      }
+      activeMQComponents.add(components.get("core"));
+      return activeMQComponents;
    }
 }

--- a/activemq-bootstrap/src/test/java/org/apache/activemq/test/FileBrokerTest.java
+++ b/activemq-bootstrap/src/test/java/org/apache/activemq/test/FileBrokerTest.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.test;
+
+import org.apache.activemq.core.server.impl.ActiveMQServerImpl;
+import org.apache.activemq.dto.ServerDTO;
+import org.apache.activemq.integration.FileBroker;
+import org.apache.activemq.jms.server.impl.JMSServerManagerImpl;
+import org.apache.activemq.spi.core.security.ActiveMQSecurityManagerImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:andy.taylor@jboss.org">Andy Taylor</a>
+ */
+public class FileBrokerTest
+{
+   @Test
+   public void startWithJMS() throws Exception
+   {
+      ServerDTO serverDTO = new ServerDTO();
+      serverDTO.configuration = "activemq-configuration.xml";
+      FileBroker broker = null;
+      try
+      {
+         broker = new FileBroker(serverDTO, new ActiveMQSecurityManagerImpl());
+         broker.start();
+         JMSServerManagerImpl jmsServerManager = (JMSServerManagerImpl) broker.getComponents().get("jms");
+         Assert.assertNotNull(jmsServerManager);
+         Assert.assertTrue(jmsServerManager.isStarted());
+         //this tells us the jms server is activated
+         Assert.assertTrue(jmsServerManager.getJMSStorageManager().isStarted());
+         ActiveMQServerImpl activeMQServer = (ActiveMQServerImpl) broker.getComponents().get("core");
+         Assert.assertNotNull(activeMQServer);
+         Assert.assertTrue(activeMQServer.isStarted());
+         Assert.assertTrue(broker.isStarted());
+      }
+      finally
+      {
+         if (broker != null)
+         {
+            broker.stop();
+         }
+      }
+   }
+
+   @Test
+   public void startWithoutJMS() throws Exception
+   {
+      ServerDTO serverDTO = new ServerDTO();
+      serverDTO.configuration = "activemq-configuration-nojms.xml";
+      FileBroker broker = null;
+      try
+      {
+         broker = new FileBroker(serverDTO, new ActiveMQSecurityManagerImpl());
+         broker.start();
+         JMSServerManagerImpl jmsServerManager = (JMSServerManagerImpl) broker.getComponents().get("jms");
+         Assert.assertNull(jmsServerManager);
+         ActiveMQServerImpl activeMQServer = (ActiveMQServerImpl) broker.getComponents().get("core");
+         Assert.assertNotNull(activeMQServer);
+         Assert.assertTrue(activeMQServer.isStarted());
+         Assert.assertTrue(broker.isStarted());
+      }
+      finally
+      {
+         assert broker != null;
+         broker.stop();
+      }
+   }
+}

--- a/activemq-bootstrap/src/test/resources/activemq-configuration-nojms.xml
+++ b/activemq-bootstrap/src/test/resources/activemq-configuration-nojms.xml
@@ -1,0 +1,73 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq">
+   <core xmlns="urn:activemq:core">
+      <paging-directory>${data.dir:../data}/paging</paging-directory>
+
+      <bindings-directory>${data.dir:../data}/bindings</bindings-directory>
+
+      <journal-directory>${data.dir:../data}/journal</journal-directory>
+
+      <journal-min-files>10</journal-min-files>
+
+      <large-messages-directory>${data.dir:../data}/large-messages</large-messages-directory>
+
+      <connectors>
+         <!-- Default Connector.  Returned to clients during broadcast and distributed around cluster.  See broadcast and discovery-groups -->
+         <connector name="activemq">tcp://${activemq.remoting.default.host:localhost}:${activemq.remoting.default.port:61616}</connector>
+      </connectors>
+
+      <acceptors>
+         <!-- Default ActiveMQ Acceptor.  Multi-protocol adapter.  Currently supports Core, OpenWire, Stomp and AMQP. -->
+         <acceptor name="activemq">tcp://${activemq.remoting.default.host:localhost}:${activemq.remoting.default.port:61616}</acceptor>
+
+         <!-- AMQP Acceptor.  Listens on default AMQP port for AMQP traffic.-->
+         <acceptor name="amqp">tcp://${activemq.remoting.amqp.host:localhost}:${activemq.remoting.amqp.port:5672}?protocols=AMQP</acceptor>
+
+         <!-- STOMP Acceptor. -->
+         <acceptor name="stomp">tcp://${activemq.remoting.stomp.host:localhost}:${activemq.remoting.stomp.port:61613}?protocols=STOMP</acceptor>
+
+         <!-- HornetQ Compatibility Acceptor.  Enables ActiveMQ Core and STOMP for legacy HornetQ clients. -->
+         <acceptor name="hornetq">tcp://${activemq.remoting.hornetq.host:localhost}:${activemq.remoting.hornetq.port:5445}?protocols=CORE,STOMP</acceptor>
+      </acceptors>
+
+      <security-settings>
+         <security-setting match="#">
+            <permission type="createNonDurableQueue" roles="guest"/>
+            <permission type="deleteNonDurableQueue" roles="guest"/>
+            <permission type="consume" roles="guest"/>
+            <permission type="send" roles="guest"/>
+         </security-setting>
+      </security-settings>
+
+      <address-settings>
+         <!--default for catch all-->
+         <address-setting match="#">
+            <dead-letter-address>jms.queue.DLQ</dead-letter-address>
+            <expiry-address>jms.queue.ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+            <max-size-bytes>10485760</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>BLOCK</address-full-policy>
+         </address-setting>
+      </address-settings>
+   </core>
+</configuration>

--- a/activemq-bootstrap/src/test/resources/activemq-configuration.xml
+++ b/activemq-bootstrap/src/test/resources/activemq-configuration.xml
@@ -1,0 +1,77 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq">
+   <jms xmlns="urn:activemq:jms">
+      <queue name="DLQ"/>
+      <queue name="ExpiryQueue"/>
+   </jms>
+   <core xmlns="urn:activemq:core">
+      <paging-directory>${data.dir:../data}/paging</paging-directory>
+
+      <bindings-directory>${data.dir:../data}/bindings</bindings-directory>
+
+      <journal-directory>${data.dir:../data}/journal</journal-directory>
+
+      <journal-min-files>10</journal-min-files>
+
+      <large-messages-directory>${data.dir:../data}/large-messages</large-messages-directory>
+
+      <connectors>
+         <!-- Default Connector.  Returned to clients during broadcast and distributed around cluster.  See broadcast and discovery-groups -->
+         <connector name="activemq">tcp://${activemq.remoting.default.host:localhost}:${activemq.remoting.default.port:61616}</connector>
+      </connectors>
+
+      <acceptors>
+         <!-- Default ActiveMQ Acceptor.  Multi-protocol adapter.  Currently supports Core, OpenWire, Stomp and AMQP. -->
+         <acceptor name="activemq">tcp://${activemq.remoting.default.host:localhost}:${activemq.remoting.default.port:61616}</acceptor>
+
+         <!-- AMQP Acceptor.  Listens on default AMQP port for AMQP traffic.-->
+         <acceptor name="amqp">tcp://${activemq.remoting.amqp.host:localhost}:${activemq.remoting.amqp.port:5672}?protocols=AMQP</acceptor>
+
+         <!-- STOMP Acceptor. -->
+         <acceptor name="stomp">tcp://${activemq.remoting.stomp.host:localhost}:${activemq.remoting.stomp.port:61613}?protocols=STOMP</acceptor>
+
+         <!-- HornetQ Compatibility Acceptor.  Enables ActiveMQ Core and STOMP for legacy HornetQ clients. -->
+         <acceptor name="hornetq">tcp://${activemq.remoting.hornetq.host:localhost}:${activemq.remoting.hornetq.port:5445}?protocols=CORE,STOMP</acceptor>
+      </acceptors>
+
+      <security-settings>
+         <security-setting match="#">
+            <permission type="createNonDurableQueue" roles="guest"/>
+            <permission type="deleteNonDurableQueue" roles="guest"/>
+            <permission type="consume" roles="guest"/>
+            <permission type="send" roles="guest"/>
+         </security-setting>
+      </security-settings>
+
+      <address-settings>
+         <!--default for catch all-->
+         <address-setting match="#">
+            <dead-letter-address>jms.queue.DLQ</dead-letter-address>
+            <expiry-address>jms.queue.ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+            <max-size-bytes>10485760</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>BLOCK</address-full-policy>
+         </address-setting>
+      </address-settings>
+   </core>
+</configuration>


### PR DESCRIPTION
...starting in standalone mode

https://issues.apache.org/jira/browse/ACTIVEMQ6-84

fixed the start order of the components started by the bootstrap