### PR TITLE
Replace file separate in ACTIVEMQ_HOME for Windows

### DIFF
--- a/activemq-bootstrap/src/main/java/org/apache/activemq/cli/commands/Run.java
+++ b/activemq-bootstrap/src/main/java/org/apache/activemq/cli/commands/Run.java
@@ -52,7 +52,11 @@ public class Run implements Action
 
       ActiveMQ.printBanner();
 
+      /* We use File URI for locating files.  The ACTIVEMQ_HOME variable is used to determine file paths.  For Windows
+      the ACTIVEMQ_HOME variable will include back slashes (An invalid file URI character path separator).  For this
+      reason we overwrite the ACTIVEMQ_HOME variable with backslashes replaced with forward slashes. */
       String activemqHome = System.getProperty("activemq.home").replace("\\", "/");
+      System.setProperty("activemq.home", activemqHome);
 
       if (configuration == null)
       {

--- a/activemq-bootstrap/src/main/java/org/apache/activemq/cli/commands/Stop.java
+++ b/activemq-bootstrap/src/main/java/org/apache/activemq/cli/commands/Stop.java
@@ -33,9 +33,15 @@ public class Stop implements Action
    @Override
    public Object execute(ActionContext context) throws Exception
    {
+      /* We use File URI for locating files.  The ACTIVEMQ_HOME variable is used to determine file paths.  For Windows
+      the ACTIVEMQ_HOME variable will include back slashes (An invalid file URI character path separator).  For this
+      reason we overwrite the ACTIVEMQ_HOME variable with backslashes replaced with forward slashes. */
+      String activemqHome = System.getProperty("activemq.home").replace("\\", "/");
+      System.setProperty("activemq.home", activemqHome);
+
       if (configuration == null)
       {
-         configuration = "xml:" + System.getProperty("activemq.home").replace("\\", "/") + "/config/non-clustered/bootstrap.xml";
+         configuration = "xml:" + activemqHome + "/config/non-clustered/bootstrap.xml";
       }
       BrokerDTO broker = BrokerFactory.createBrokerConfiguration(configuration);
 


### PR DESCRIPTION
ActiveMQ uses URI's for locating files on a file system.  Absolute file
URIs are generated using an ACTIVEMQ_HOME variable defined via the start
up scripts.  For Windows this will contain "\" character as file path
separator.  This is invalid for the file URI scheme.  This patch
rewrites the ACTIVEMQ_HOME variable ensuring "/" are used on both
Windows and Linux.

Tested on Windows 8 only.