### PR TITLE
Fixing examples on windows

### DIFF
--- a/activemq-maven-plugin/src/main/java/org/apache/activemq/server/ActiveMQBootstrap.java
+++ b/activemq-maven-plugin/src/main/java/org/apache/activemq/server/ActiveMQBootstrap.java
@@ -98,14 +98,14 @@ public class ActiveMQBootstrap
          {
             //extendPluginClasspath(configurationDir);
             configuration = new FileConfiguration();
-            File file = new File(configurationDir + "/" + "activemq-configuration.xml");
+            File file = new File(new File(configurationDir), "activemq-configuration.xml");
             jmsFileConfiguration = new FileJMSConfiguration();
-            FileDeploymentManager deploymentManager = new FileDeploymentManager(file.toURI().toURL().toExternalForm());
+            FileDeploymentManager deploymentManager = new FileDeploymentManager(file.toURI().toString());
             deploymentManager.addDeployable((FileConfiguration)configuration);
             deploymentManager.addDeployable((FileJMSConfiguration) jmsFileConfiguration);
 
-            securityConfiguration = new FileSecurityConfiguration("file://" + configurationDir + "/" + "activemq-users.properties",
-                                                                  "file://" + configurationDir + "/" + "activemq-roles.properties",
+            securityConfiguration = new FileSecurityConfiguration(new File(configurationDir, "activemq-users.properties").toURI().toString(),
+                                                                  new File(configurationDir, "activemq-roles.properties").toURI().toString(),
                                                                   "guest",
                                                                   false,
                                                                   null);


### PR DESCRIPTION
The examples on windows are not working properly
This is because we are using concatenation to locate directories instead of File(parent, child)
Using that constructor we can then convert to URI and that would work independently of the OS