### PR TITLE
Add source build to release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -494,6 +494,49 @@
             <module>examples</module>
             <module>distribution</module>
          </modules>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-assembly-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <goals>
+                           <goal>single</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                           <finalName>apache-activemq-${project.version}</finalName>
+                           <runOnlyAtExecutionRoot>true</runOnlyAtExecutionRoot>
+                           <descriptorRefs>
+                              <descriptorRef>
+                                 source-release
+                              </descriptorRef>
+                           </descriptorRefs>
+                        </configuration>
+                     </execution>
+                  </executions>
+                  <dependencies>
+                     <dependency>
+                        <!-- apache version not yet released -->
+                        <!--<groupId>org.apache</groupId>-->
+                        <groupId>org.apache.geronimo.genesis</groupId>
+                        <artifactId>apache-source-release-assembly-descriptor</artifactId>
+                        <!-- apache version not yet known -->
+                        <version>2.0</version>
+                     </dependency>
+                  </dependencies>
+               </plugin>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <version>2.14.1</version>
+                  <configuration>
+                     <test>false</test>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
       </profile>
       <profile>
          <id>hudson-tests</id>


### PR DESCRIPTION
This should rename the source build to apache-activemq-6.0.0-source-release.zip.

It still need verification with the apache-release plugin.  We can add now and fix if we hit an issue on the next release.

Note:  This must be performed on a clean checkout, as it currently does not ignore idea files.  I will follow up post release with a better solution.