### PR TITLE
Add source assembly to distribution build

### DIFF
--- a/distribution/activemq/pom.xml
+++ b/distribution/activemq/pom.xml
@@ -183,6 +183,38 @@
          <build>
          </build>
       </profile>
+      <profile>
+         <id>source-release</id>
+         <activation>
+            <property>
+               <name>apache-release</name>
+            </property>
+         </activation>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-deploy-plugin</artifactId>
+               </plugin>
+               <plugin>
+                  <artifactId>maven-assembly-plugin</artifactId>
+                  <version>2.2</version>
+                  <configuration>
+                     <descriptor>src/main/assembly/source-assembly.xml</descriptor>
+                     <tarLongFileMode>gnu</tarLongFileMode>
+                  </configuration>
+                  <executions>
+                     <execution>
+                        <phase>package</phase>
+                        <goals>
+                           <goal>single</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
    </profiles>
 
    <build>

--- a/distribution/activemq/src/main/assembly/source-assembly.xml
+++ b/distribution/activemq/src/main/assembly/source-assembly.xml
@@ -1,0 +1,108 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
+   <id>source-release</id>
+
+   <formats>
+      <format>zip</format>
+      <format>tar.gz</format>
+   </formats>
+
+   <includeBaseDirectory>true</includeBaseDirectory>
+
+   <fileSets>
+      <!--  main project directory structure  -->
+      <fileSet>
+         <directory>${activemq.basedir}</directory>
+         <outputDirectory>/</outputDirectory>
+         <useDefaultExcludes>true</useDefaultExcludes>
+         <!-- TODO These excludes were lifted from maven-resources-apache-source-release-assembly-descriptor-1.0.4. We
+         should use this descriptor directly in future -->
+         <excludes>
+            <!--  build output  -->
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/).*${project.build.directory}.*]
+            </exclude>
+            <!--
+             NOTE: Most of the following excludes should not be required
+                         if the standard release process is followed. This is because the
+                         release plugin checks out project sources into a location like
+                         target/checkout, then runs the build from there. The result is
+                         a source-release archive that comes from a pretty clean directory
+                         structure.
+
+                         HOWEVER, if the release plugin is configured to run extra goals
+                         or generate a project website, it's definitely possible that some
+                         of these files will be present. So, it's safer to exclude them.
+
+            -->
+            <!--  IDEs  -->
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?maven-eclipse\.xml]
+            </exclude>
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.project]
+            </exclude>
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.classpath]
+            </exclude>
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?[^/]*\.iws]
+            </exclude>
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.idea(/.*)?]
+            </exclude>
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?out(/.*)?]
+            </exclude>
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?[^/]*\.ipr]
+            </exclude>
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?[^/]*\.iml]
+            </exclude>
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.settings(/.*)?]
+            </exclude>
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.externalToolBuilders(/.*)?]
+            </exclude>
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.deployables(/.*)?]
+            </exclude>
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.wtpmodules(/.*)?]
+            </exclude>
+            <!--  misc  -->
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?cobertura\.ser]
+            </exclude>
+            <!--  release-plugin temp files  -->
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?pom\.xml\.releaseBackup]
+            </exclude>
+            <exclude>
+               %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?release\.properties]
+            </exclude>
+         </excludes>
+      </fileSet>
+   </fileSets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -495,7 +495,6 @@
             <module>examples</module>
             <module>distribution</module>
          </modules>
-         
       </profile>
       <profile>
          <!-- tests is the profile we use to run the entire testsuite
@@ -599,52 +598,6 @@
             <module>tests</module>
             <module>examples</module>
          </modules>
-         <properties>
-            <skipTests>true</skipTests>
-         </properties>
-      </profile>
-      <profile>
-         <id>apache-release</id>
-         <activation>
-            <property>
-               <name>apache-release</name>
-            </property>
-         </activation>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-assembly-plugin</artifactId>
-                  <executions>
-                     <execution>
-                        <goals>
-                           <goal>single</goal>
-                        </goals>
-                        <phase>package</phase>
-                        <configuration>
-                           <finalName>apache-activemq-${project.version}</finalName>
-                           <runOnlyAtExecutionRoot>true</runOnlyAtExecutionRoot>
-                           <descriptorRefs>
-                              <descriptorRef>
-                                 source-release
-                              </descriptorRef>
-                           </descriptorRefs>
-                        </configuration>
-                     </execution>
-                  </executions>
-                  <dependencies>
-                     <dependency>
-                        <!-- apache version not yet released -->
-                        <!--<groupId>org.apache</groupId>-->
-                        <groupId>org.apache.geronimo.genesis</groupId>
-                        <artifactId>apache-source-release-assembly-descriptor</artifactId>
-                        <!-- apache version not yet known -->
-                        <version>2.0</version>
-                     </dependency>
-                  </dependencies>
-               </plugin>
-            </plugins>
-         </build>
          <properties>
             <skipTests>true</skipTests>
          </properties>


### PR DESCRIPTION
Builds the source assembly in the distribution build, and fixes previous issues of including unwanted files.  Still to do is the disabling of the source assembly on the top level pom as inherited by the Apache 16.