### PR TITLE
Moving ActiveMQLoggerHandler away from clashing package util

### DIFF
--- a/activemq-commons/src/main/java/org/apache/activemq/logs/ActiveMQUtilBundle.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/logs/ActiveMQUtilBundle.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.utils;
+package org.apache.activemq.logs;
 
 
 import org.apache.activemq.api.core.ActiveMQIllegalStateException;

--- a/activemq-commons/src/main/java/org/apache/activemq/logs/ActiveMQUtilLogger.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/logs/ActiveMQUtilLogger.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.utils;
+package org.apache.activemq.logs;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;

--- a/activemq-commons/src/main/java/org/apache/activemq/logs/AssertionLoggerHandler.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/logs/AssertionLoggerHandler.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.utils;
+package org.apache.activemq.logs;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/activemq-commons/src/main/java/org/apache/activemq/utils/PasswordMaskingUtil.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/utils/PasswordMaskingUtil.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.apache.activemq.api.core.ActiveMQException;
 import org.apache.activemq.api.core.ActiveMQExceptionType;
+import org.apache.activemq.logs.ActiveMQUtilBundle;
 
 /**
  * A PasswordMarkingUtil

--- a/activemq-commons/src/main/java/org/apache/activemq/utils/TypedProperties.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/utils/TypedProperties.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.apache.activemq.api.core.ActiveMQBuffer;
 import org.apache.activemq.api.core.ActiveMQPropertyConversionException;
 import org.apache.activemq.api.core.SimpleString;
+import org.apache.activemq.logs.ActiveMQUtilBundle;
 
 import static org.apache.activemq.utils.DataConstants.BOOLEAN;
 import static org.apache.activemq.utils.DataConstants.BYTE;

--- a/activemq-commons/src/main/java/org/apache/activemq/utils/UTF8Util.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/utils/UTF8Util.java
@@ -19,6 +19,8 @@ package org.apache.activemq.utils;
 import java.lang.ref.SoftReference;
 
 import org.apache.activemq.api.core.ActiveMQBuffer;
+import org.apache.activemq.logs.ActiveMQUtilBundle;
+import org.apache.activemq.logs.ActiveMQUtilLogger;
 
 /**
  *

--- a/activemq-commons/src/main/java/org/apache/activemq/utils/UUIDGenerator.java
+++ b/activemq-commons/src/main/java/org/apache/activemq/utils/UUIDGenerator.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.api.core.SimpleString;
+import org.apache.activemq.logs.ActiveMQUtilLogger;
 
 public final class UUIDGenerator
 {

--- a/activemq-server/src/test/java/org/apache/activemq/core/config/impl/WrongRoleFileConfigurationParserTest.java
+++ b/activemq-server/src/test/java/org/apache/activemq/core/config/impl/WrongRoleFileConfigurationParserTest.java
@@ -20,7 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.activemq.core.deployers.impl.FileConfigurationParser;
-import org.apache.activemq.utils.AssertionLoggerHandler;
+import org.apache.activemq.logs.AssertionLoggerHandler;
 import org.apache.activemq.tests.util.UnitTestCase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/activemq-server/src/test/resources/logging.properties
+++ b/activemq-server/src/test/resources/logging.properties
@@ -45,7 +45,7 @@ handler.FILE.formatter=PATTERN
 
 
 # Console handler configuration
-handler.TEST=org.apache.activemq.utils.AssertionLoggerHandler
+handler.TEST=org.apache.activemq.logs.AssertionLoggerHandler
 handler.TEST.level=TRACE
 handler.TEST.formatter=PATTERN
 

--- a/tests/config/logging.properties
+++ b/tests/config/logging.properties
@@ -51,7 +51,7 @@ handler.FILE.fileName=target/activemq.log
 handler.FILE.formatter=PATTERN
 
 # Console handler configuration
-handler.TEST=org.apache.activemq.utils.AssertionLoggerHandler
+handler.TEST=org.apache.activemq.logs.AssertionLoggerHandler
 handler.TEST.level=TRACE
 handler.TEST.formatter=PATTERN
 

--- a/tests/config/logging.properties.trace
+++ b/tests/config/logging.properties.trace
@@ -53,7 +53,7 @@ handler.FILE.fileName=target/activemq.log
 handler.FILE.formatter=PATTERN
 
 # Console handler configuration
-handler.TEST=org.apache.activemq.utils.AssertionLoggerHandler
+handler.TEST=org.apache.activemq.logs.AssertionLoggerHandler
 handler.TEST.level=TRACE
 handler.TEST.formatter=PATTERN
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/client/PagingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/client/PagingTest.java
@@ -73,7 +73,7 @@ import org.apache.activemq.core.server.impl.ActiveMQServerImpl;
 import org.apache.activemq.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.core.settings.impl.AddressSettings;
 import org.apache.activemq.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.utils.AssertionLoggerHandler;
+import org.apache.activemq.logs.AssertionLoggerHandler;
 import org.apache.activemq.tests.util.ServiceTestBase;
 import org.apache.activemq.tests.util.UnitTestCase;
 import org.junit.Assert;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/server/AddressFullLoggingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/server/AddressFullLoggingTest.java
@@ -33,7 +33,7 @@ import org.apache.activemq.api.core.client.ServerLocator;
 import org.apache.activemq.core.server.ActiveMQServer;
 import org.apache.activemq.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.core.settings.impl.AddressSettings;
-import org.apache.activemq.utils.AssertionLoggerHandler;
+import org.apache.activemq.logs.AssertionLoggerHandler;
 import org.apache.activemq.tests.util.ServiceTestBase;
 import org.junit.AfterClass;
 import org.junit.Assert;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/server/FileLockTimeoutTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/server/FileLockTimeoutTest.java
@@ -27,7 +27,7 @@ import org.apache.activemq.core.config.ha.SharedStoreMasterPolicyConfiguration;
 import org.apache.activemq.core.server.ActiveMQServer;
 import org.apache.activemq.core.server.JournalType;
 import org.apache.activemq.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.utils.AssertionLoggerHandler;
+import org.apache.activemq.logs.AssertionLoggerHandler;
 import org.apache.activemq.tests.util.ServiceTestBase;
 import org.junit.AfterClass;
 import org.junit.Assert;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/server/SimpleStartStopTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/server/SimpleStartStopTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.activemq.core.persistence.impl.journal.JournalRecordIds;
 import org.apache.activemq.core.server.ActiveMQServer;
-import org.apache.activemq.utils.AssertionLoggerHandler;
+import org.apache.activemq.logs.AssertionLoggerHandler;
 import org.apache.activemq.tests.util.ServiceTestBase;
 import org.jboss.logmanager.Level;
 import org.junit.Test;


### PR DESCRIPTION
This was causing issues with javadoc
utils is also a package on activemq-server. ActiveMQUtilLogger is using a super class that was not part of the
source path on the javadoc plugin what caused it to exception and interrupt building