### PR TITLE
Added possibility to intercept stomp frames

### DIFF
--- a/activemq-protocols/activemq-stomp-protocol/src/main/java/org/apache/activemq/core/protocol/stomp/StompFrameInterceptor.java
+++ b/activemq-protocols/activemq-stomp-protocol/src/main/java/org/apache/activemq/core/protocol/stomp/StompFrameInterceptor.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.core.protocol.stomp;
+
+import org.apache.activemq.api.core.ActiveMQException;
+import org.apache.activemq.api.core.Interceptor;
+import org.apache.activemq.core.protocol.core.Packet;
+import org.apache.activemq.spi.core.protocol.RemotingConnection;
+
+/**
+ * This class is a simple way to intercepting client calls on ActiveMQ using STOMP protocol.
+ * <p>
+ * To add an interceptor to ActiveMQ server, you have to modify the server configuration file
+ * {@literal activemq-configuration.xml}.<br>
+ */
+public abstract class StompFrameInterceptor implements Interceptor
+{
+
+   /**
+    * Intercepts a packet which is received before it is sent to the channel.
+    * By default does not do anything and returns true allowing other interceptors perform logic.
+    *
+    * @param packet     the packet being received
+    * @param connection the connection the packet was received on
+    * @return {@code true} to process the next interceptor and handle the packet,
+    * {@code false} to abort processing of the packet
+    * @throws ActiveMQException
+    */
+   @Override
+   public boolean intercept(Packet packet, RemotingConnection connection) throws ActiveMQException
+   {
+      return true;
+   }
+
+  /**
+   * Intercepts a stomp frame sent by a client.
+   *
+   * @param stompFrame     the stomp frame being received
+   * @param connection the connection the stomp frame was received on
+   * @return {@code true} to process the next interceptor and handle the stomp frame,
+   * {@code false} to abort processing of the stomp frame
+   */
+   public abstract boolean intercept(StompFrame stompFrame, RemotingConnection connection);
+}

--- a/activemq-protocols/activemq-stomp-protocol/src/main/java/org/apache/activemq/core/protocol/stomp/StompProtocolManager.java
+++ b/activemq-protocols/activemq-stomp-protocol/src/main/java/org/apache/activemq/core/protocol/stomp/StompProtocolManager.java
@@ -79,13 +79,14 @@ class StompProtocolManager implements ProtocolManager, NotificationListener
 
    private final Set<String> destinations = new ConcurrentHashSet<String>();
 
-   private final List<Interceptor> interceptors;
+   private final List<Interceptor> incomingInterceptors;
+   private final List<Interceptor> outgoingInterceptors;
 
    // Static --------------------------------------------------------
 
    // Constructors --------------------------------------------------
 
-   public StompProtocolManager(final ActiveMQServer server, final List<Interceptor> interceptors)
+   public StompProtocolManager(final ActiveMQServer server, final List<Interceptor> incomingInterceptors, final List<Interceptor> outgoingInterceptors)
    {
       this.server = server;
       this.executor = server.getExecutorFactory().getExecutor();
@@ -96,7 +97,8 @@ class StompProtocolManager implements ProtocolManager, NotificationListener
          destinations.add(service.getManagementAddress().toString());
          service.addNotificationListener(this);
       }
-      this.interceptors = interceptors;
+      this.incomingInterceptors = incomingInterceptors;
+      this.outgoingInterceptors = outgoingInterceptors;
    }
 
    @Override
@@ -169,26 +171,7 @@ class StompProtocolManager implements ProtocolManager, NotificationListener
 
          try
          {
-            if (this.interceptors != null && !this.interceptors.isEmpty())
-            {
-               for (Interceptor interceptor : this.interceptors)
-               {
-                  if (interceptor instanceof StompFrameInterceptor)
-                  {
-                     try
-                     {
-                        if (!((StompFrameInterceptor)interceptor).intercept(request, conn))
-                        {
-                           break;
-                        }
-                     }
-                     catch (Exception e)
-                     {
-                        ActiveMQServerLogger.LOGGER.error(e);
-                     }
-                  }
-               }
-            }
+            invokeInterceptors(this.incomingInterceptors, request, conn);
             conn.handleFrame(request);
          }
          finally
@@ -224,6 +207,9 @@ class StompProtocolManager implements ProtocolManager, NotificationListener
       {
          ActiveMQServerLogger.LOGGER.trace("sent " + frame);
       }
+
+      invokeInterceptors(this.outgoingInterceptors, frame, connection);
+
       synchronized (connection)
       {
          if (connection.isDestroyed())
@@ -526,5 +512,29 @@ class StompProtocolManager implements ProtocolManager, NotificationListener
    public ActiveMQServer getServer()
    {
       return server;
+   }
+
+   private void invokeInterceptors(List<Interceptor> interceptors, final StompFrame frame, final StompConnection connection)
+   {
+      if (interceptors != null && !interceptors.isEmpty())
+      {
+         for (Interceptor interceptor : interceptors)
+         {
+            if (interceptor instanceof StompFrameInterceptor)
+            {
+               try
+               {
+                  if (!((StompFrameInterceptor)interceptor).intercept(frame, connection))
+                  {
+                     break;
+                  }
+               }
+               catch (Exception e)
+               {
+                  ActiveMQServerLogger.LOGGER.error(e);
+               }
+            }
+         }
+      }
    }
 }

--- a/activemq-protocols/activemq-stomp-protocol/src/main/java/org/apache/activemq/core/protocol/stomp/StompProtocolManagerFactory.java
+++ b/activemq-protocols/activemq-stomp-protocol/src/main/java/org/apache/activemq/core/protocol/stomp/StompProtocolManagerFactory.java
@@ -31,7 +31,7 @@ public class StompProtocolManagerFactory implements ProtocolManagerFactory
 
    public ProtocolManager createProtocolManager(final ActiveMQServer server, final List<Interceptor> incomingInterceptors, List<Interceptor> outgoingInterceptors)
    {
-      return new StompProtocolManager(server, incomingInterceptors);
+      return new StompProtocolManager(server, incomingInterceptors, outgoingInterceptors);
    }
 
    @Override

--- a/docs/user-manual/en/intercepting-operations.md
+++ b/docs/user-manual/en/intercepting-operations.md
@@ -20,6 +20,17 @@ public interface Interceptor
 }
 ```
 
+For stomp protocol an interceptor must extend the `StompFrameInterceptor class`:
+
+``` java
+package org.apache.activemq.core.protocol.stomp;
+
+public abstract class StompFrameInterceptor
+{
+   public abstract boolean intercept(StompFrame stompFrame, RemotingConnection connection);
+}
+```
+
 The returned boolean value is important:
 
 -   if `true` is returned, the process continues normally

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/stomp/ExtraStompTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/stomp/ExtraStompTest.java
@@ -20,14 +20,18 @@ import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.QueueBrowser;
 import javax.jms.TextMessage;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.activemq.api.core.TransportConfiguration;
 import org.apache.activemq.api.core.client.ActiveMQClient;
 import org.apache.activemq.core.config.Configuration;
 import org.apache.activemq.core.protocol.stomp.Stomp;
+import org.apache.activemq.core.protocol.stomp.StompFrame;
+import org.apache.activemq.core.protocol.stomp.StompFrameInterceptor;
 import org.apache.activemq.core.protocol.stomp.StompProtocolManagerFactory;
 import org.apache.activemq.core.registry.JndiBindingRegistry;
 import org.apache.activemq.core.remoting.impl.invm.InVMAcceptorFactory;
@@ -41,6 +45,7 @@ import org.apache.activemq.jms.server.config.impl.JMSConfigurationImpl;
 import org.apache.activemq.jms.server.config.impl.JMSQueueConfigurationImpl;
 import org.apache.activemq.jms.server.config.impl.TopicConfigurationImpl;
 import org.apache.activemq.jms.server.impl.JMSServerManagerImpl;
+import org.apache.activemq.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.tests.integration.largemessage.LargeMessageTestBase;
 import org.apache.activemq.tests.integration.largemessage.LargeMessageTestBase.TestLargeMessageInputStream;
 import org.apache.activemq.tests.integration.stomp.util.ClientStompFrame;
@@ -811,6 +816,102 @@ public class ExtraStompTest extends StompTestBase
                                                 .setName(getTopicName())
                                                 .setBindings(getTopicName()));
       server = new JMSServerManagerImpl(activeMQServer, jmsConfig);
+      server.setRegistry(new JndiBindingRegistry(new InVMNamingContext()));
+      return server;
+   }
+
+   static List<StompFrame> interceptedFrames = new ArrayList<StompFrame>();
+
+   public static class MyStompFrameInterceptor extends StompFrameInterceptor
+   {
+
+      @Override
+      public boolean intercept(StompFrame stompFrame, RemotingConnection connection)
+      {
+         interceptedFrames.add(stompFrame);
+         stompFrame.addHeader("interceptedProp", "interceptedVal");
+         return true;
+      }
+   }
+
+   @Test
+   public void stompFrameInterceptor() throws Exception
+   {
+      try
+      {
+         List<String> interceptorList = new ArrayList<String>();
+         interceptorList.add("org.apache.activemq.tests.integration.stomp.ExtraStompTest$MyStompFrameInterceptor");
+         server = createServerWithStompInterceptor(interceptorList);
+         server.start();
+
+         setUpAfterServer();
+
+         String connect_frame = "CONNECT\n" + "login: brianm\n"
+                 + "passcode: wombats\n" + "request-id: 1\n" + "\n" + Stomp.NULL;
+         sendFrame(connect_frame);
+
+         String frame = "SEND\n" + "destination:" + getQueuePrefix()
+                 + getQueueName() + "\n\n" + "Hello World 1" + Stomp.NULL;
+         sendFrame(frame);
+
+         frame = "SEND\n" + "destination:" + getQueuePrefix() + getQueueName()
+                 + "\n\n" + "Hello World 2" + Stomp.NULL;
+         sendFrame(frame);
+
+         MessageConsumer consumer = session.createConsumer(queue);
+
+         TextMessage message = (TextMessage) consumer.receive(1000);
+         Assert.assertNotNull(message);
+         Assert.assertEquals("interceptedVal", message.getStringProperty("interceptedProp"));
+
+         message = (TextMessage) consumer.receive(1000);
+         Assert.assertNotNull(message);
+         Assert.assertEquals("interceptedVal", message.getStringProperty("interceptedProp"));
+
+         List<String> commandsSent = new ArrayList<String>(3);
+         commandsSent.add("CONNECT");
+         commandsSent.add("SEND");
+         commandsSent.add("SEND");
+
+         for (int i = 0; i < 3; i++)
+         {
+            Assert.assertEquals(commandsSent.get(i), interceptedFrames.get(i).getCommand());
+         }
+
+      }
+      finally
+      {
+         cleanUp();
+         server.stop();
+      }
+   }
+
+   protected JMSServerManager createServerWithStompInterceptor(List<String> stompInterceptor) throws Exception
+   {
+
+      Map<String, Object> params = new HashMap<String, Object>();
+      params.put(TransportConstants.PROTOCOLS_PROP_NAME, StompProtocolManagerFactory.STOMP_PROTOCOL_NAME);
+      params.put(TransportConstants.PORT_PROP_NAME, TransportConstants.DEFAULT_STOMP_PORT);
+      params.put(TransportConstants.STOMP_CONSUMERS_CREDIT, "-1");
+      TransportConfiguration stompTransport = new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params);
+
+      Configuration config = createBasicConfig()
+              .setPersistenceEnabled(false)
+              .addAcceptorConfiguration(stompTransport)
+              .addAcceptorConfiguration(new TransportConfiguration(INVM_ACCEPTOR_FACTORY))
+              .setIncomingInterceptorClassNames(stompInterceptor);
+
+      ActiveMQServer hornetQServer = addServer(ActiveMQServers.newActiveMQServer(config, defUser, defPass));
+
+      JMSConfiguration jmsConfig = new JMSConfigurationImpl();
+      jmsConfig.getQueueConfigurations().add(new JMSQueueConfigurationImpl()
+              .setName(getQueueName())
+              .setDurable(false)
+              .setBindings(getQueueName()));
+      jmsConfig.getTopicConfigurations().add(new TopicConfigurationImpl()
+              .setName(getTopicName())
+              .setBindings(getTopicName()));
+      server = new JMSServerManagerImpl(hornetQServer, jmsConfig);
       server.setRegistry(new JndiBindingRegistry(new InVMNamingContext()));
       return server;
    }


### PR DESCRIPTION
Initially I was trying to log all the incoming stomp frames from the client on a server side, but could not find any easy way of doing this. This pr adds possibility to intercept stomp frames via interceptor section in activemq-configuration.xml. 

Interceptor list was already passed as a parameter to StompProtocolManager constructor, but was not used in any way. I decided to introduce new abstract class which implements Interceptor interface as the simplest solution and then invoke its intercept method like it is done with the regular interceptors. 

Clients need to extend this class and put it under activemq class path, just as a regular jms interceptor.

Looking forward to your comments, and feel free to reject it in case it does not make any sense.