### PR TITLE
ACTIVEMQ6-94: HornetQ Bridge does not handle large messages

### DIFF
--- a/activemq-core-client/src/main/java/org/apache/activemq/core/client/impl/ClientProducerImpl.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/core/client/impl/ClientProducerImpl.java
@@ -415,11 +415,11 @@ public class ClientProducerImpl implements ClientProducerInternal
       try
       {
 
-         for (int pos = 0; pos < bodySize; )
+         for (long pos = 0; pos < bodySize; )
          {
             final boolean lastChunk;
 
-            final int chunkLength = Math.min((int) (bodySize - pos), minLargeMessageSize);
+            final int chunkLength = (int)Math.min((bodySize - pos), (long)minLargeMessageSize);
 
             final ActiveMQBuffer bodyBuffer = ActiveMQBuffers.fixedBuffer(chunkLength);
 
@@ -430,7 +430,7 @@ public class ClientProducerImpl implements ClientProducerInternal
             lastChunk = pos >= bodySize;
             SendAcknowledgementHandler messageHandler = lastChunk ? handler : null;
 
-            int creditsUsed = sessionContext.sendLargeMessageChunk(msgI, -1, sendBlocking, lastChunk, bodyBuffer.toByteBuffer().array(), messageHandler);
+            int creditsUsed = sessionContext.sendServerLargeMessageChunk(msgI, -1, sendBlocking, lastChunk, bodyBuffer.toByteBuffer().array(), messageHandler);
 
             try
             {

--- a/activemq-core-client/src/main/java/org/apache/activemq/core/protocol/core/Channel.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/core/protocol/core/Channel.java
@@ -201,4 +201,15 @@ public interface Channel
     * @param transferring whether the channel is transferring
     */
    void setTransferring(boolean transferring);
+
+   /**
+    * for large message server send, each entry in resend cache will hold a reference to
+    * a chunk of bytes which can cause OOM if the cache quickly build up. This method
+    * make sure the resent cache size can't be more than one by blocking the call.
+    *
+    * @param timeout max waiting time for the resend cache
+    *
+    * @return true if the resend cache gets cleared
+    */
+   boolean largeServerCheck(long timeout);
 }

--- a/activemq-core-client/src/main/java/org/apache/activemq/spi/core/remoting/SessionContext.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/spi/core/remoting/SessionContext.java
@@ -149,6 +149,8 @@ public abstract class SessionContext
 
    public abstract int sendLargeMessageChunk(MessageInternal msgI, long messageBodySize, boolean sendBlocking, boolean lastChunk, byte[] chunk, SendAcknowledgementHandler messageHandler) throws ActiveMQException;
 
+   public abstract int sendServerLargeMessageChunk(MessageInternal msgI, long messageBodySize, boolean sendBlocking, boolean lastChunk, byte[] chunk, SendAcknowledgementHandler messageHandler) throws ActiveMQException;
+
 
    public abstract void setSendAcknowledgementHandler(final SendAcknowledgementHandler handler);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/cluster/util/BackupSyncDelay.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/cluster/util/BackupSyncDelay.java
@@ -376,6 +376,12 @@ public class BackupSyncDelay implements Interceptor
       }
 
       @Override
+      public boolean largeServerCheck(long timeout)
+      {
+         return true;
+      }
+
+      @Override
       public boolean supports(byte packetID)
       {
          return true;


### PR DESCRIPTION
  When sending a large message that exceeds the size of
Integer.MAX_VALUE, the bridge will get negative chunk size during
fowarding. And the resend cache is not limited so there is a
potential that it may get OutOfMemory exception.