### PR TITLE
ACTIVEMQ6-95 Large Message doesn't work on clustering & null Persistence

### DIFF
--- a/activemq-server/src/main/java/org/apache/activemq/core/persistence/impl/nullpm/NullStorageLargeServerMessage.java
+++ b/activemq-server/src/main/java/org/apache/activemq/core/persistence/impl/nullpm/NullStorageLargeServerMessage.java
@@ -19,6 +19,7 @@ package org.apache.activemq.core.persistence.impl.nullpm;
 import org.apache.activemq.api.core.ActiveMQBuffers;
 import org.apache.activemq.core.journal.SequentialFile;
 import org.apache.activemq.core.server.LargeServerMessage;
+import org.apache.activemq.core.server.ServerMessage;
 import org.apache.activemq.core.server.impl.ServerMessageImpl;
 
 class NullStorageLargeServerMessage extends ServerMessageImpl implements LargeServerMessage
@@ -27,6 +28,11 @@ class NullStorageLargeServerMessage extends ServerMessageImpl implements LargeSe
    public NullStorageLargeServerMessage()
    {
       super();
+   }
+
+   public NullStorageLargeServerMessage(NullStorageLargeServerMessage other)
+   {
+      super(other);
    }
 
    @Override
@@ -79,7 +85,13 @@ class NullStorageLargeServerMessage extends ServerMessageImpl implements LargeSe
    @Override
    public String toString()
    {
-      return "LargeServerMessage[messageID=" + messageID + ", durable=" + durable + ", address=" + getAddress()  + ",properties=" + properties.toString() + "]";
+      return "NullStorageLargeServerMessage[messageID=" + messageID + ", durable=" + durable + ", address=" + getAddress()  + ",properties=" + properties.toString() + "]";
+   }
+
+   public ServerMessage copy()
+   {
+      // This is a simple copy, used only to avoid changing original properties
+      return new NullStorageLargeServerMessage(this);
    }
 
    @Override

--- a/activemq-server/src/test/java/org/apache/activemq/tests/util/UnitTestCase.java
+++ b/activemq-server/src/test/java/org/apache/activemq/tests/util/UnitTestCase.java
@@ -282,7 +282,7 @@ public abstract class UnitTestCase extends CoreUnitTestCase
     * @return
     * @throws Exception
     */
-   protected final ConfigurationImpl createBasicConfig(final int serverID)
+   protected ConfigurationImpl createBasicConfig(final int serverID)
    {
       ConfigurationImpl configuration = new ConfigurationImpl()
          .setSecurityEnabled(false)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ACTIVEMQ6-95

The message.copy is broken when you set persistence=false, and the bridge will use that method before forwarding the message
this commit is fixing NullStorageLargeServerMessage.copy and adding the proper testcase to validate the fix