### PR TITLE
using temporary folders under ./target

### DIFF
--- a/activemq-server/src/test/java/org/apache/activemq/tests/util/RemoveFolder.java
+++ b/activemq-server/src/test/java/org/apache/activemq/tests/util/RemoveFolder.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.tests.util;
+
+import java.io.File;
+
+import org.junit.rules.ExternalResource;
+
+/**
+ * This will remove a folder on a tearDown *
+ */
+public class RemoveFolder extends ExternalResource
+{
+   private final String folderName;
+
+   public RemoveFolder(String folderName)
+   {
+      this.folderName = folderName;
+   }
+
+   /**
+    * Override to tear down your specific external resource.
+    */
+   protected void after()
+   {
+      UnitTestCase.deleteDirectory(new File(folderName));
+   }
+}

--- a/activemq-server/src/test/java/org/apache/activemq/tests/util/UnitTestCase.java
+++ b/activemq-server/src/test/java/org/apache/activemq/tests/util/UnitTestCase.java
@@ -123,13 +123,21 @@ import org.junit.rules.TestName;
  */
 public abstract class UnitTestCase extends CoreUnitTestCase
 {
+   public static final String TARGET_TMP = "./target/tmp";
    // Constants -----------------------------------------------------
 
    @Rule
    public TestName name = new TestName();
 
    @Rule
-   public TemporaryFolder temporaryFolder = new TemporaryFolder();
+   public TemporaryFolder temporaryFolder;
+
+   @Rule
+   // This Custom rule will remove any files under ./target/tmp
+   // including anything created previously by TemporaryFolder
+   public RemoveFolder folder = new RemoveFolder(TARGET_TMP);
+
+
    private String testDir;
 
    private static final ActiveMQServerLogger log = ActiveMQServerLogger.LOGGER;
@@ -146,6 +154,14 @@ public abstract class UnitTestCase extends CoreUnitTestCase
 
    private static final String OS_TYPE = System.getProperty("os.name").toLowerCase();
    private static final int DEFAULT_UDP_PORT;
+
+
+   public UnitTestCase()
+   {
+      File parent = new File(TARGET_TMP);
+      parent.mkdirs();
+      temporaryFolder = new TemporaryFolder(parent);
+   }
 
    static
    {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/discovery/DiscoveryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/discovery/DiscoveryTest.java
@@ -76,7 +76,7 @@ public class DiscoveryTest extends DiscoveryBaseTest
    public void tearDown() throws Exception
    {
       /** This file path is defined at {@link #TEST_JGROUPS_CONF_FILE} */
-      deleteDirectory(new File("/tmp/amqtest.ping.dir"));
+      deleteDirectory(new File("./target/tmp/amqtest.ping.dir"));
       for (ActiveMQComponent component : new ActiveMQComponent[]{bg, bg1, bg2, bg3, dg, dg1, dg2, dg3})
       {
          stopComponent(component);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/jms/server/JMSServerStartStopTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/jms/server/JMSServerStartStopTest.java
@@ -200,10 +200,6 @@ public class JMSServerStartStopTest extends UnitTestCase
       deploymentManager.addDeployable(fileConfiguration);
       deploymentManager.readConfiguration();
 
-      fc.setJournalDirectory(getJournalDir());
-      fc.setBindingsDirectory(getBindingsDir());
-      fc.setLargeMessagesDirectory(getLargeMessagesDir());
-
       ActiveMQSecurityManager sm = new ActiveMQSecurityManagerImpl();
 
       ActiveMQServer liveServer = addServer(new ActiveMQServerImpl(fc, sm));

--- a/tests/integration-tests/src/test/resources/colocated-server-start-stop-config1.xml
+++ b/tests/integration-tests/src/test/resources/colocated-server-start-stop-config1.xml
@@ -22,10 +22,10 @@
       <connector name="netty-connector">tcp://localhost:61616</connector>
    </connectors>
 
-   <paging-directory>/tmp/activemq-unit-test/live1/paging</paging-directory>
-   <bindings-directory>/tmp/activemq-unit-test/live1/binding</bindings-directory>
-   <journal-directory>/tmp/activemq-unit-test/live1/journal</journal-directory>
-   <large-messages-directory>/tmp/activemq-unit-test/live1/largemessages</large-messages-directory>
+   <paging-directory>./target/tmp/activemq-unit-test/live1/paging</paging-directory>
+   <bindings-directory>./target/tmp/activemq-unit-test/live1/binding</bindings-directory>
+   <journal-directory>./target/tmp/activemq-unit-test/live1/journal</journal-directory>
+   <large-messages-directory>./target/tmp/activemq-unit-test/live1/largemessages</large-messages-directory>
    
    <acceptors>
       <acceptor name="netty-acceptor">tcp://localhost:61616</acceptor>
@@ -62,10 +62,10 @@
    <backup-servers>
       <backup-server name="myBackup" port-offset="100" inherit-configuration="true" backup-strategy="FULL">
           <configuration>
-              <paging-directory>/tmp/activemq-unit-test/live2/paging</paging-directory>
-              <bindings-directory>/tmp/activemq-unit-test/live2/binding</bindings-directory>
-              <journal-directory>/tmp/activemq-unit-test/live2/journal</journal-directory>
-              <large-messages-directory>/tmp/activemq-unit-test/live2/largemessages</large-messages-directory>
+              <paging-directory>./target/tmp/activemq-unit-test/live2/paging</paging-directory>
+              <bindings-directory>./target/tmp/activemq-unit-test/live2/binding</bindings-directory>
+              <journal-directory>./target/tmp/activemq-unit-test/live2/journal</journal-directory>
+              <large-messages-directory>./target/tmp/activemq-unit-test/live2/largemessages</large-messages-directory>
           </configuration>
       </backup-server>
    </backup-servers>

--- a/tests/integration-tests/src/test/resources/colocated-server-start-stop-config2.xml
+++ b/tests/integration-tests/src/test/resources/colocated-server-start-stop-config2.xml
@@ -22,11 +22,11 @@
       <connector name="netty-connector">tcp://localhost:5645</connector>
    </connectors>
 
-   <paging-directory>/tmp/activemq-unit-test/live2/paging</paging-directory>
-   <bindings-directory>/tmp/activemq-unit-test/live2/binding</bindings-directory>
-   <journal-directory>/tmp/activemq-unit-test/live2/journal</journal-directory>
-   <large-messages-directory>/tmp/activemq-unit-test/live2/largemessages</large-messages-directory>
-   
+   <paging-directory>./target/tmp/activemq-unit-test/live2/paging</paging-directory>
+   <bindings-directory>./target/tmp/activemq-unit-test/live2/binding</bindings-directory>
+   <journal-directory>./target/tmp/activemq-unit-test/live2/journal</journal-directory>
+   <large-messages-directory>./target/tmp/activemq-unit-test/live2/largemessages</large-messages-directory>
+
    <acceptors>
       <acceptor name="netty-acceptor">tcp://localhost:5645</acceptor>
    </acceptors>
@@ -61,10 +61,10 @@
    <backup-servers>
       <backup-server name="myBackup" port-offset="100" inherit-configuration="true" backup-strategy="FULL">
           <configuration>
-              <paging-directory>/tmp/activemq-unit-test/live1/paging</paging-directory>
-              <bindings-directory>/tmp/activemq-unit-test/live1/binding</bindings-directory>
-              <journal-directory>/tmp/activemq-unit-test/live1/journal</journal-directory>
-              <large-messages-directory>/tmp/activemq-unit-test/live1/largemessages</large-messages-directory>
+              <paging-directory>./target/tmp/activemq-unit-test/live1/paging</paging-directory>
+              <bindings-directory>./target/tmp/activemq-unit-test/live1/binding</bindings-directory>
+              <journal-directory>./target/tmp/activemq-unit-test/live1/journal</journal-directory>
+              <large-messages-directory>./target/tmp/activemq-unit-test/live1/largemessages</large-messages-directory>
           </configuration>
       </backup-server>
    </backup-servers>

--- a/tests/integration-tests/src/test/resources/server-start-stop-config1.xml
+++ b/tests/integration-tests/src/test/resources/server-start-stop-config1.xml
@@ -26,7 +26,7 @@
          <connector name="netty-connector">tcp://localhost:61616</connector>
       </connectors>
 
-      <journal-directory>/tmp/activemq-unit-test/start-stop-data</journal-directory>
+      <journal-directory>./target/tmp/activemq-unit-test/start-stop-data</journal-directory>
 
       <acceptors>
          <acceptor name="netty-acceptor">tcp://localhost:61616</acceptor>

--- a/tests/integration-tests/src/test/resources/test-jgroups-file_ping.xml
+++ b/tests/integration-tests/src/test/resources/test-jgroups-file_ping.xml
@@ -43,7 +43,7 @@
          oob_thread_pool.queue_max_size="100"
          oob_thread_pool.rejection_policy="run"/>
 
-    <FILE_PING location="/tmp/hqtest.ping.dir"/>
+    <FILE_PING location="./target/tmp/amqtest.ping.dir"/>
     <MERGE2 max_interval="30000"
               min_interval="10000"/>
     <FD_SOCK/>


### PR DESCRIPTION
Sometimes /tmp doesn't support ext4 (most times is tmpfs under linux) and there's always a risk of leaving unnatended files in cases of crashed.

This is in alignment with how other tests run at apache.

Developers will be able to use tmpfs now