### PR TITLE
Queue Auto-create fixes on OpenWire

### DIFF
--- a/activemq-core-client/src/main/java/org/apache/activemq/api/core/client/ClientSession.java
+++ b/activemq-core-client/src/main/java/org/apache/activemq/api/core/client/ClientSession.java
@@ -27,6 +27,25 @@ import org.apache.activemq.api.core.SimpleString;
  */
 public interface ClientSession extends XAResource, AutoCloseable
 {
+
+   /**
+    * This is used to identify a ClientSession as used by the JMS Layer
+    * The JMS Layer will add this through Meta-data, so the server or management layers
+    * can identify session created over core API purely or through the JMS Layer
+    */
+   String JMS_SESSION_IDENTIFIER_PROPERTY = "jms-session";
+
+
+   /**
+    * Just like {@link org.apache.activemq.api.core.client.ClientSession.AddressQuery#JMS_SESSION_IDENTIFIER_PROPERTY} this is
+    * used to identify the ClientID over JMS Session.
+    * However this is only used when the JMS Session.clientID is set (which is optional).
+    * With this property management tools and the server can identify the jms-client-id used over JMS
+    */
+   String JMS_SESSION_CLIENT_ID_PROPERTY = "jms-client-id";
+
+
+
    /**
     * Information returned by a binding query
     *

--- a/activemq-jms-client/src/main/java/org/apache/activemq/jms/client/ActiveMQConnection.java
+++ b/activemq-jms-client/src/main/java/org/apache/activemq/jms/client/ActiveMQConnection.java
@@ -230,7 +230,7 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
 
       try
       {
-         initialSession.addUniqueMetaData("jms-client-id", clientID);
+         initialSession.addUniqueMetaData(ClientSession.JMS_SESSION_CLIENT_ID_PROPERTY, clientID);
       }
       catch (ActiveMQException e)
       {
@@ -732,10 +732,10 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
 
    private void addSessionMetaData(ClientSession session) throws ActiveMQException
    {
-      session.addMetaData("jms-session", "");
+      session.addMetaData(ClientSession.JMS_SESSION_IDENTIFIER_PROPERTY, "");
       if (clientID != null)
       {
-         session.addMetaData("jms-client-id", clientID);
+         session.addMetaData(ClientSession.JMS_SESSION_CLIENT_ID_PROPERTY, clientID);
       }
    }
 

--- a/activemq-jms-client/src/main/java/org/apache/activemq/jms/client/ActiveMQMessageProducer.java
+++ b/activemq-jms-client/src/main/java/org/apache/activemq/jms/client/ActiveMQMessageProducer.java
@@ -409,16 +409,12 @@ public class ActiveMQMessageProducer implements MessageProducer, QueueSender, To
             try
             {
                ClientSession.AddressQuery query = clientSession.addressQuery(address);
-               if (!query.isExists())
+
+               // if it's autoCreateJMSQueue we will let the PostOffice.route to execute the creation at the server's side
+               // as that's a more efficient path for such operation
+               if (!query.isExists() && !query.isAutoCreateJmsQueues())
                {
-                  if (query.isAutoCreateJmsQueues())
-                  {
-                     clientSession.createQueue(address, address, true);
-                  }
-                  else
-                  {
-                     throw new InvalidDestinationException("Destination " + address + " does not exist");
-                  }
+                  throw new InvalidDestinationException("Destination " + address + " does not exist");
                }
                else
                {

--- a/activemq-protocols/activemq-amqp-protocol/src/main/java/org/apache/activemq/core/protocol/proton/plug/ProtonSessionIntegrationCallback.java
+++ b/activemq-protocols/activemq-amqp-protocol/src/main/java/org/apache/activemq/core/protocol/proton/plug/ProtonSessionIntegrationCallback.java
@@ -105,7 +105,8 @@ public class ProtonSessionIntegrationCallback implements AMQPSessionCallback, Se
                                                         true, //boolean xa,
                                                         (String) null,
                                                         this,
-                                                        null);
+                                                        null,
+                                                        true);
    }
 
    @Override

--- a/activemq-protocols/activemq-openwire-protocol/src/main/java/org/apache/activemq/core/protocol/openwire/amq/AMQServerSession.java
+++ b/activemq-protocols/activemq-openwire-protocol/src/main/java/org/apache/activemq/core/protocol/openwire/amq/AMQServerSession.java
@@ -44,6 +44,7 @@ import org.apache.activemq.core.server.ActiveMQMessageBundle;
 import org.apache.activemq.core.server.ActiveMQServerLogger;
 import org.apache.activemq.core.server.MessageReference;
 import org.apache.activemq.core.server.Queue;
+import org.apache.activemq.core.server.QueueCreator;
 import org.apache.activemq.core.server.ServerConsumer;
 import org.apache.activemq.core.server.ServerMessage;
 import org.apache.activemq.core.server.impl.ActiveMQServerImpl;
@@ -72,6 +73,7 @@ public class AMQServerSession extends ServerSessionImpl
          SecurityStore securityStore, ManagementService managementService,
          ActiveMQServerImpl activeMQServerImpl, SimpleString managementAddress,
          SimpleString simpleString, SessionCallback callback,
+         QueueCreator queueCreator,
          OperationContext context) throws Exception
    {
       super(name, username, password,
@@ -83,7 +85,8 @@ public class AMQServerSession extends ServerSessionImpl
          securityStore, managementService,
          activeMQServerImpl, managementAddress,
          simpleString, callback,
-         context, new AMQTransactionFactory());
+         context, new AMQTransactionFactory(),
+         queueCreator);
    }
 
    //create a fake session just for security check
@@ -387,7 +390,7 @@ public class AMQServerSession extends ServerSessionImpl
 
       try
       {
-         postOffice.route(msg, routingContext, direct);
+         postOffice.route(msg, getQueueCreator(), routingContext, direct);
 
          Pair<UUID, AtomicLong> value = targetAddressInfos.get(msg.getAddress());
 

--- a/activemq-protocols/activemq-openwire-protocol/src/main/java/org/apache/activemq/core/protocol/openwire/amq/AMQServerSessionFactory.java
+++ b/activemq-protocols/activemq-openwire-protocol/src/main/java/org/apache/activemq/core/protocol/openwire/amq/AMQServerSessionFactory.java
@@ -21,6 +21,7 @@ import org.apache.activemq.core.persistence.OperationContext;
 import org.apache.activemq.core.persistence.StorageManager;
 import org.apache.activemq.core.postoffice.PostOffice;
 import org.apache.activemq.core.security.SecurityStore;
+import org.apache.activemq.core.server.QueueCreator;
 import org.apache.activemq.core.server.ServerSessionFactory;
 import org.apache.activemq.core.server.impl.ActiveMQServerImpl;
 import org.apache.activemq.core.server.impl.ServerSessionImpl;
@@ -41,13 +42,13 @@ public class AMQServerSessionFactory implements ServerSessionFactory
          PostOffice postOffice, ResourceManager resourceManager,
          SecurityStore securityStore, ManagementService managementService,
          ActiveMQServerImpl activeMQServerImpl, SimpleString managementAddress,
-         SimpleString simpleString, SessionCallback callback,
+         SimpleString simpleString, SessionCallback callback, QueueCreator queueCreator,
          OperationContext context) throws Exception
    {
       return new AMQServerSession(name, username, password, minLargeMessageSize, autoCommitSends,
             autoCommitAcks, preAcknowledge, persistDeliveryCountBeforeDelivery, xa,
             connection, storageManager, postOffice, resourceManager, securityStore,
-            managementService, activeMQServerImpl, managementAddress, simpleString, callback,
+            managementService, activeMQServerImpl, managementAddress, simpleString, callback, queueCreator,
             context);
    }
 

--- a/activemq-protocols/activemq-stomp-protocol/src/main/java/org/apache/activemq/core/protocol/stomp/StompProtocolManager.java
+++ b/activemq-protocols/activemq-stomp-protocol/src/main/java/org/apache/activemq/core/protocol/stomp/StompProtocolManager.java
@@ -274,7 +274,7 @@ class StompProtocolManager implements ProtocolManager<StompFrameInterceptor>, No
                                                       false,
                                                       false,
                                                       null,
-                                                      stompSession, null);
+                                                      stompSession, null, true);
          stompSession.setServerSession(session);
          sessions.put(connection.getID(), stompSession);
       }
@@ -299,7 +299,7 @@ class StompProtocolManager implements ProtocolManager<StompFrameInterceptor>, No
                                                       false,
                                                       false,
                                                       null,
-                                                      stompSession, null);
+                                                      stompSession, null, true);
          stompSession.setServerSession(session);
          transactedSessions.put(txID, stompSession);
       }

--- a/activemq-ra/src/main/java/org/apache/activemq/ra/inflow/ActiveMQActivation.java
+++ b/activemq-ra/src/main/java/org/apache/activemq/ra/inflow/ActiveMQActivation.java
@@ -561,11 +561,11 @@ public class ActiveMQActivation
                                    spec.getTransactionTimeout());
 
          result.addMetaData("resource-adapter", "inbound");
-         result.addMetaData("jms-session", "");
+         result.addMetaData(ClientSession.JMS_SESSION_IDENTIFIER_PROPERTY, "");
          String clientID = ra.getClientID() == null ? spec.getClientID() : ra.getClientID();
          if (clientID != null)
          {
-            result.addMetaData("jms-client-id", clientID);
+            result.addMetaData(ClientSession.JMS_SESSION_CLIENT_ID_PROPERTY, clientID);
          }
 
          ActiveMQRALogger.LOGGER.debug("Using queue connection " + result);

--- a/activemq-server/src/main/java/org/apache/activemq/core/postoffice/PostOffice.java
+++ b/activemq-server/src/main/java/org/apache/activemq/core/postoffice/PostOffice.java
@@ -24,6 +24,7 @@ import org.apache.activemq.api.core.SimpleString;
 import org.apache.activemq.core.server.ActiveMQComponent;
 import org.apache.activemq.core.server.MessageReference;
 import org.apache.activemq.core.server.Queue;
+import org.apache.activemq.core.server.QueueCreator;
 import org.apache.activemq.core.server.RoutingContext;
 import org.apache.activemq.core.server.ServerMessage;
 import org.apache.activemq.core.transaction.Transaction;
@@ -66,15 +67,15 @@ public interface PostOffice extends ActiveMQComponent
 
    Map<SimpleString, Binding> getAllBindings();
 
-   void route(ServerMessage message, boolean direct) throws Exception;
+   void route(ServerMessage message, QueueCreator queueCreator, boolean direct) throws Exception;
 
-   void route(ServerMessage message, Transaction tx, boolean direct) throws Exception;
+   void route(ServerMessage message, QueueCreator queueCreator, Transaction tx, boolean direct) throws Exception;
 
-   void route(ServerMessage message, Transaction tx, boolean direct, boolean rejectDuplicates) throws Exception;
+   void route(ServerMessage message, QueueCreator queueCreator, Transaction tx, boolean direct, boolean rejectDuplicates) throws Exception;
 
-   void route(ServerMessage message, RoutingContext context, boolean direct) throws Exception;
+   void route(ServerMessage message, QueueCreator queueCreator, RoutingContext context, boolean direct) throws Exception;
 
-   void route(ServerMessage message, RoutingContext context, boolean direct, boolean rejectDuplicates) throws Exception;
+   void route(ServerMessage message, QueueCreator queueCreator, RoutingContext context, boolean direct, boolean rejectDuplicates) throws Exception;
 
    MessageReference reroute(ServerMessage message, Queue queue, Transaction tx) throws Exception;
 

--- a/activemq-server/src/main/java/org/apache/activemq/core/protocol/core/impl/ActiveMQPacketHandler.java
+++ b/activemq-server/src/main/java/org/apache/activemq/core/protocol/core/impl/ActiveMQPacketHandler.java
@@ -177,7 +177,7 @@ public class ActiveMQPacketHandler implements ChannelHandler
                                                       request.getDefaultAddress(),
                                                       new CoreSessionCallback(request.getName(),
                                                                               protocolManager,
-                                                                              channel), null);
+                                                                              channel), null, true);
 
          ServerSessionPacketHandler handler = new ServerSessionPacketHandler(session,
                                                                              server.getStorageManager(),

--- a/activemq-server/src/main/java/org/apache/activemq/core/server/ActiveMQServer.java
+++ b/activemq-server/src/main/java/org/apache/activemq/core/server/ActiveMQServer.java
@@ -111,7 +111,8 @@ public interface ActiveMQServer extends ActiveMQComponent
                                boolean xa,
                                String defaultAddress,
                                SessionCallback callback,
-                               ServerSessionFactory sessionFactory) throws Exception;
+                               ServerSessionFactory sessionFactory,
+                               boolean autoCreateQueues) throws Exception;
 
    SecurityStore getSecurityStore();
 
@@ -141,6 +142,19 @@ public interface ActiveMQServer extends ActiveMQComponent
    SimpleString getNodeID();
 
    boolean isActive();
+
+   /**
+    * This is the queue creator responsible for JMS Queue creations*
+    * @param queueCreator
+    */
+   void setJMSQueueCreator(QueueCreator queueCreator);
+
+   /**
+    * @see {@link org.apache.activemq.core.server.ActiveMQServer#setJMSQueueCreator(QueueCreator)} *
+    * *
+    * @return
+    */
+   QueueCreator getJMSQueueCreator();
 
    /**
     * Wait for server initialization.

--- a/activemq-server/src/main/java/org/apache/activemq/core/server/QueueCreator.java
+++ b/activemq-server/src/main/java/org/apache/activemq/core/server/QueueCreator.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.core.server;
+
+import org.apache.activemq.api.core.SimpleString;
+
+public interface QueueCreator
+{
+   /**
+    *
+    * You should return true if you even tried to create the queue and the queue was already there.
+    * As the callers of this method will use that as an indicator that they should re-route the messages.
+    * *
+    * @return True if a queue was created.
+    */
+   boolean create(SimpleString address) throws Exception;
+}

--- a/activemq-server/src/main/java/org/apache/activemq/core/server/ServerSession.java
+++ b/activemq-server/src/main/java/org/apache/activemq/core/server/ServerSession.java
@@ -75,6 +75,8 @@ public interface ServerSession
 
    void xaSuspend() throws Exception;
 
+   QueueCreator getQueueCreator();
+
    List<Xid> xaGetInDoubtXids();
 
    int xaGetTimeout();

--- a/activemq-server/src/main/java/org/apache/activemq/core/server/ServerSessionFactory.java
+++ b/activemq-server/src/main/java/org/apache/activemq/core/server/ServerSessionFactory.java
@@ -40,6 +40,6 @@ public interface ServerSessionFactory
          SecurityStore securityStore, ManagementService managementService,
          ActiveMQServerImpl activeMQServerImpl, SimpleString managementAddress,
          SimpleString simpleString, SessionCallback callback,
-         OperationContext context) throws Exception;
+         QueueCreator queueCreator, OperationContext context) throws Exception;
 
 }

--- a/activemq-server/src/main/java/org/apache/activemq/core/server/impl/DivertImpl.java
+++ b/activemq-server/src/main/java/org/apache/activemq/core/server/impl/DivertImpl.java
@@ -110,7 +110,7 @@ public class DivertImpl implements Divert
          copy = message;
       }
 
-      postOffice.route(copy, context.getTransaction(), false);
+      postOffice.route(copy, null, context.getTransaction(), false);
    }
 
    @Override

--- a/activemq-server/src/main/java/org/apache/activemq/core/server/impl/QueueImpl.java
+++ b/activemq-server/src/main/java/org/apache/activemq/core/server/impl/QueueImpl.java
@@ -2449,7 +2449,7 @@ public class QueueImpl implements Queue
 
       copyMessage.setAddress(toAddress);
 
-      postOffice.route(copyMessage, tx, false, rejectDuplicate);
+      postOffice.route(copyMessage, null, tx, false, rejectDuplicate);
 
       acknowledge(tx, ref);
    }
@@ -2673,7 +2673,7 @@ public class QueueImpl implements Queue
 
       copyMessage.setAddress(address);
 
-      postOffice.route(copyMessage, tx, false, rejectDuplicate);
+      postOffice.route(copyMessage, null, tx, false, rejectDuplicate);
 
       acknowledge(tx, ref);
 

--- a/activemq-server/src/main/java/org/apache/activemq/core/server/management/impl/ManagementServiceImpl.java
+++ b/activemq-server/src/main/java/org/apache/activemq/core/server/management/impl/ManagementServiceImpl.java
@@ -728,7 +728,7 @@ public class ManagementServiceImpl implements ManagementService
                                                         new SimpleString(notification.getUID()));
                }
 
-               postOffice.route(notificationMessage, false);
+               postOffice.route(notificationMessage, null, false);
             }
          }
       }

--- a/integration/activemq-vertx-integration/src/main/java/org/apache/activemq/integration/vertx/IncomingVertxEventHandler.java
+++ b/integration/activemq-vertx-integration/src/main/java/org/apache/activemq/integration/vertx/IncomingVertxEventHandler.java
@@ -175,7 +175,7 @@ public class IncomingVertxEventHandler implements ConnectorService
 
          try
          {
-            postOffice.route(msg, false);
+            postOffice.route(msg, null, false);
          }
          catch (Exception e)
          {

--- a/tests/extra-tests/src/test/java/org/apache/activemq/tests/extras/jms/bridge/JMSBridgeTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/tests/extras/jms/bridge/JMSBridgeTest.java
@@ -1399,7 +1399,7 @@ public class JMSBridgeTest extends BridgeTestBase
 
             if (on)
             {
-               String header = tm.getStringProperty(ActiveMQJMSConstants.JBOSS_MESSAGING_BRIDGE_MESSAGE_ID_LIST);
+               String header = tm.getStringProperty(ActiveMQJMSConstants.AMQ_MESSAGING_BRIDGE_MESSAGE_ID_LIST);
 
                Assert.assertNotNull(header);
 
@@ -1449,7 +1449,7 @@ public class JMSBridgeTest extends BridgeTestBase
 
                Assert.assertEquals("mygroup543", tm.getStringProperty("JMSXGroupID"));
 
-               String header = tm.getStringProperty(ActiveMQJMSConstants.JBOSS_MESSAGING_BRIDGE_MESSAGE_ID_LIST);
+               String header = tm.getStringProperty(ActiveMQJMSConstants.AMQ_MESSAGING_BRIDGE_MESSAGE_ID_LIST);
 
                Assert.assertNotNull(header);
 
@@ -1749,7 +1749,7 @@ public class JMSBridgeTest extends BridgeTestBase
             Assert.assertTrue(tm.getBooleanProperty("cheese"));
             Assert.assertEquals(23, tm.getIntProperty("Sausages"));
 
-            String header = tm.getStringProperty(ActiveMQJMSConstants.JBOSS_MESSAGING_BRIDGE_MESSAGE_ID_LIST);
+            String header = tm.getStringProperty(ActiveMQJMSConstants.AMQ_MESSAGING_BRIDGE_MESSAGE_ID_LIST);
 
             Assert.assertNull(header);
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/client/AutoCreateJmsQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/client/AutoCreateJmsQueueTest.java
@@ -73,6 +73,38 @@ public class AutoCreateJmsQueueTest extends JMSTestBase
    }
 
    @Test
+   public void testAutoCreateOnSendToQueueAnonymousProducer() throws Exception
+   {
+      Connection connection = cf.createConnection();
+      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+      javax.jms.Queue queue = ActiveMQJMSClient.createQueue("test");
+
+      MessageProducer producer = session.createProducer(null);
+
+      final int numMessages = 100;
+
+      for (int i = 0; i < numMessages; i++)
+      {
+         TextMessage mess = session.createTextMessage("msg" + i);
+         producer.send(queue, mess);
+      }
+
+      producer.close();
+
+      MessageConsumer messageConsumer = session.createConsumer(queue);
+      connection.start();
+
+      for (int i = 0; i < numMessages; i++)
+      {
+         Message m = messageConsumer.receive(5000);
+         Assert.assertNotNull(m);
+      }
+
+      connection.close();
+   }
+
+   @Test
    public void testAutoCreateOnSendToQueueSecurity() throws Exception
    {
       ((ActiveMQSecurityManagerImpl)server.getSecurityManager()).getConfiguration().addUser("guest", "guest");

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/client/HangConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/client/HangConsumerTest.java
@@ -661,7 +661,7 @@ public class HangConsumerTest extends ServiceTestBase
       }
 
       @Override
-      protected ServerSessionImpl internalCreateSession(String name, String username, String password, int minLargeMessageSize, RemotingConnection connection, boolean autoCommitSends, boolean autoCommitAcks, boolean preAcknowledge, boolean xa, String defaultAddress, SessionCallback callback, OperationContext context, ServerSessionFactory sessionFactory) throws Exception
+      protected ServerSessionImpl internalCreateSession(String name, String username, String password, int minLargeMessageSize, RemotingConnection connection, boolean autoCommitSends, boolean autoCommitAcks, boolean preAcknowledge, boolean xa, String defaultAddress, SessionCallback callback, OperationContext context, ServerSessionFactory sessionFactory, boolean autoCreateQueue) throws Exception
       {
          return new ServerSessionImpl(name,
             username,
@@ -683,7 +683,8 @@ public class HangConsumerTest extends ServiceTestBase
             defaultAddress == null ? null
                : new SimpleString(defaultAddress),
             new MyCallback(callback),
-            context);
+            context,
+            null);
       }
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/openwire/OpenWireTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/openwire/OpenWireTestBase.java
@@ -16,16 +16,15 @@
  */
 package org.apache.activemq.tests.integration.openwire;
 
+import javax.jms.ConnectionFactory;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import javax.jms.ConnectionFactory;
-import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 
 import org.apache.activemq.api.core.SimpleString;
 import org.apache.activemq.api.core.TransportConfiguration;
@@ -75,6 +74,7 @@ public class OpenWireTestBase extends ServiceTestBase
       Map<String, AddressSettings> addressSettings = serverConfig.getAddressesSettings();
       String match = "jms.queue.#";
       AddressSettings dlaSettings = new AddressSettings();
+      dlaSettings.setAutoCreateJmsQueues(false);
       SimpleString dla = new SimpleString("jms.queue.ActiveMQ.DLQ");
       dlaSettings.setDeadLetterAddress(dla);
       addressSettings.put(match, dlaSettings);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/openwire/SimpleOpenWireTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/openwire/SimpleOpenWireTest.java
@@ -32,6 +32,7 @@ import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.activemq.command.ActiveMQTopic;
 import org.apache.activemq.core.settings.impl.AddressSettings;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -291,6 +292,32 @@ public class SimpleOpenWireTest extends BasicOpenWireTest
 
       TextMessage message1 = (TextMessage) consumer.receive(1000);
       assertTrue(message1.getText().equals(message.getText()));
+   }
+
+   @Test
+   public void testAutoDestinationNoCreationOnConsumer() throws JMSException
+   {
+      AddressSettings addressSetting = new AddressSettings();
+      addressSetting.setAutoCreateJmsQueues(false);
+
+      String address = "foo";
+      server.getAddressSettingsRepository().addMatch("jms.queue." + address, addressSetting);
+
+      connection.start();
+      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+      TextMessage message = session.createTextMessage("bar");
+      Queue queue = new ActiveMQQueue(address);
+
+      try
+      {
+         MessageConsumer consumer = session.createConsumer(queue);
+         Assert.fail("supposed to throw an exception here");
+      }
+      catch (JMSException e)
+      {
+
+      }
    }
 
    /**

--- a/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/openwire/amq/ProducerFlowControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/tests/integration/openwire/amq/ProducerFlowControlTest.java
@@ -16,26 +16,25 @@
  */
 package org.apache.activemq.tests.integration.openwire.amq;
 
-import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import javax.jms.DeliveryMode;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TextMessage;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.command.ActiveMQQueue;
-import org.apache.activemq.transport.tcp.TcpTransport;
 import org.apache.activemq.core.config.Configuration;
 import org.apache.activemq.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.core.settings.impl.AddressSettings;
 import org.apache.activemq.tests.integration.openwire.BasicOpenWireTest;
+import org.apache.activemq.transport.tcp.TcpTransport;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/tests/unit-tests/src/test/java/org/apache/activemq/tests/unit/core/server/impl/fakes/FakePostOffice.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/tests/unit/core/server/impl/fakes/FakePostOffice.java
@@ -29,6 +29,7 @@ import org.apache.activemq.core.postoffice.PostOffice;
 import org.apache.activemq.core.postoffice.impl.DuplicateIDCacheImpl;
 import org.apache.activemq.core.server.MessageReference;
 import org.apache.activemq.core.server.Queue;
+import org.apache.activemq.core.server.QueueCreator;
 import org.apache.activemq.core.server.RoutingContext;
 import org.apache.activemq.core.server.ServerMessage;
 import org.apache.activemq.core.server.impl.MessageReferenceImpl;
@@ -153,45 +154,27 @@ public class FakePostOffice implements PostOffice
       return new MessageReferenceImpl();
    }
 
-   public void route(final ServerMessage message, final Transaction tx) throws Exception
+   public void route(ServerMessage message, QueueCreator creator, RoutingContext context, boolean direct) throws Exception
    {
 
 
    }
 
-   public void route(final ServerMessage message, final RoutingContext context) throws Exception
-   {
-
-
-   }
-
-   public void route(ServerMessage message, boolean direct) throws Exception
-   {
-
-
-   }
-
-   public void route(ServerMessage message, RoutingContext context, boolean direct) throws Exception
-   {
-
-
-   }
-
-   public void route(ServerMessage message, Transaction tx, boolean direct) throws Exception
+   public void route(ServerMessage message, QueueCreator creator, Transaction tx, boolean direct) throws Exception
    {
 
 
    }
 
    @Override
-   public void route(ServerMessage message, RoutingContext context, boolean direct, boolean rejectDuplicates) throws Exception
+   public void route(ServerMessage message, QueueCreator creator, RoutingContext context, boolean direct, boolean rejectDuplicates) throws Exception
    {
 
 
    }
 
    @Override
-   public void route(ServerMessage message, Transaction tx, boolean direct, boolean rejectDuplicates) throws Exception
+   public void route(ServerMessage message, QueueCreator creator, Transaction tx, boolean direct, boolean rejectDuplicates) throws Exception
    {
 
 
@@ -200,8 +183,11 @@ public class FakePostOffice implements PostOffice
    @Override
    public void processRoute(ServerMessage message, RoutingContext context, boolean direct) throws Exception
    {
-
-
    }
 
+   @Override
+   public void route(ServerMessage message, QueueCreator queueCreator, boolean direct) throws Exception
+   {
+
+   }
 }


### PR DESCRIPTION
this is basically addressing a performance issue on OpenWire, setting the auto-create to the PostOffice
after not being able to route

The core protocol stays the same in regard to the auto-create since the exceptions are happening after the queueQuery